### PR TITLE
Majestic settings & Startup scripts (device gk7202v300_lite_cootli_camv0103)

### DIFF
--- a/devices/gk7202v300_lite_cootli_camv0103/general/overlay/etc/init.d/S35pinworks
+++ b/devices/gk7202v300_lite_cootli_camv0103/general/overlay/etc/init.d/S35pinworks
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+case "$1" in
+        start)
+
+            # Bring power to SD CARD (GPIO70)
+            gpio clear 70
+            gpio unexport 70
+
+            # same thru devmem
+            #devmem 0x120B8400 32 0x40		# set GPIO8_6 to output
+            #devmem 0x120B8100 32 0x00		# set GPIO8_6 to LO
+
+            # bumping SDHCI driver
+            echo 10010000.sdhci > /sys/bus/platform/drivers/sdhci-goke/unbind
+            echo 10010000.sdhci > /sys/bus/platform/drivers/sdhci-goke/bind
+
+esac
+
+exit 0

--- a/devices/gk7202v300_lite_cootli_camv0103/general/overlay/etc/init.d/S80pinworks
+++ b/devices/gk7202v300_lite_cootli_camv0103/general/overlay/etc/init.d/S80pinworks
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+case "$1" in
+        start)
+
+            # Unmuxing GPIO12, GPIO14, GPIO15 (motor H connector. pins 5, 4, 3)
+            devmem 0x120c0010 32 0x1e02
+            devmem 0x120c0018 32 0x1d02
+            devmem 0x120c001c 32 0x1402
+
+            # Unpower motors winding (GPIO13 is HI after kernel modules load)
+            gpio clear 13
+            gpio unexport 13
+
+esac
+
+exit 0

--- a/devices/gk7202v300_lite_cootli_camv0103/general/overlay/usr/share/openipc/customizer.sh
+++ b/devices/gk7202v300_lite_cootli_camv0103/general/overlay/usr/share/openipc/customizer.sh
@@ -15,5 +15,17 @@ fw_setenv upgrade 'https://github.com/OpenIPC/builder/releases/download/latest/g
 fw_setenv wlandev ssv6x5x-generic
 #fw_setenv wlanssid Router
 #fw_setenv wlanpass 12345678
+#
+# Set majestic settings
+#
+cli -s .nightMode.enabled true
+cli -s .nightMode.irCutPin1 56
+cli -s .nightMode.irCutPin2 58
+cli -s .nightMode.backlightPin 16
+cli -s .nightMode.minThreshold 2000
+cli -s .nightMode.maxThreshold 17000
+cli -s .audio.enabled true
+cli -s .audio.outputEnabled true
+cli -s .audio.speakerPin 51
 
 exit 0


### PR DESCRIPTION
- In customizer.sh: added pins for IRCUT, IRLED, Speaker
- init.d -> S35pinworks: workaround about SD Card power and reinit
- init.d -> S80pinworks: Unmuxing GPIO pins routed to motors connector

[Article related to this board](https://github.com/OpenIPC/wiki/blob/master/en/device-IPC-RM1-BLK7202V3-M43A-WIFI.md)