### PR TITLE
Support transition from hi3516ev200_isp to open_isp @ hi3516ev200

### DIFF
--- a/devices/hi3516ev300_ultimate_rostelecom-ipc8232swc-we/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
+++ b/devices/hi3516ev300_ultimate_rostelecom-ipc8232swc-we/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
@@ -103,7 +103,7 @@ insert_detect() {
 	modprobe open_sys_config chip=${chipid} sensors=unknown g_cmos_yuv_flag=$YUV_TYPE0 board=${board}
 	insert_osal
 	modprobe open_base
-	modprobe hi3516ev200_isp
+	modprobe open_isp
 	modprobe open_sensor_i2c
 	modprobe open_sensor_spi
 }
@@ -111,7 +111,7 @@ insert_detect() {
 remove_detect() {
 	rmmod -w open_sensor_spi
 	rmmod -w open_sensor_i2c
-	rmmod -w hi3516ev200_isp
+	rmmod -w open_isp
 	rmmod -w open_base
 	rmmod -w open_osal
 	rmmod -w open_sys_config
@@ -141,7 +141,7 @@ remove_audio() {
 }
 
 insert_isp() {
-	modprobe hi3516ev200_isp
+	modprobe open_isp
 }
 
 insert_sil9024() {
@@ -226,7 +226,7 @@ remove_ko() {
 	#	rmmod -w hifb
 	#	rmmod -w open_vo
 	rmmod -w open_vpss
-	rmmod -w hi3516ev200_isp
+	rmmod -w open_isp
 	rmmod -w open_vi
 	rmmod -w open_vgs
 	rmmod -w open_rgn

--- a/devices/hi3516ev300_ultimate_rvi-1ncmw2028/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
+++ b/devices/hi3516ev300_ultimate_rvi-1ncmw2028/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
@@ -103,7 +103,7 @@ insert_detect() {
 	modprobe open_sys_config chip=${chipid} sensors=unknown g_cmos_yuv_flag=$YUV_TYPE0 board=${board}
 	insert_osal
 	modprobe open_base
-	modprobe hi3516ev200_isp
+	modprobe open_isp
 	modprobe open_sensor_i2c
 	modprobe open_sensor_spi
 }
@@ -111,7 +111,7 @@ insert_detect() {
 remove_detect() {
 	rmmod -w open_sensor_spi
 	rmmod -w open_sensor_i2c
-	rmmod -w hi3516ev200_isp
+	rmmod -w open_isp
 	rmmod -w open_base
 	rmmod -w open_osal
 	rmmod -w open_sys_config
@@ -141,7 +141,7 @@ remove_audio() {
 }
 
 insert_isp() {
-	modprobe hi3516ev200_isp
+	modprobe open_isp
 }
 
 insert_sil9024() {
@@ -226,7 +226,7 @@ remove_ko() {
 	#	rmmod -w hifb
 	#	rmmod -w open_vo
 	rmmod -w open_vpss
-	rmmod -w hi3516ev200_isp
+	rmmod -w open_isp
 	rmmod -w open_vi
 	rmmod -w open_vgs
 	rmmod -w open_rgn


### PR DESCRIPTION
Previusly discussed in https://github.com/OpenIPC/firmware/issues/1991