### PR TITLE
ci: add build-one workflow for single-platform test builds

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -1,0 +1,81 @@
+name: build-one
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Platform to build (e.g. hi3518ev200_lite_switcam-hs303-v2)'
+        required: true
+
+env:
+  TAG_NAME: latest
+
+jobs:
+  buildroot:
+    name: Firmware (${{inputs.platform}})
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Prepare firmware
+        run: |
+          echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf
+          echo CACHE_DATE=$(date +%m) >> ${GITHUB_ENV}
+
+      - name: Setup ccache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/ccache
+          key: ${{inputs.platform}}-${{env.CACHE_DATE}}
+
+      - name: Build firmware
+        run: |
+          export GIT_HASH=$(git rev-parse --short ${GITHUB_SHA})
+          export GIT_BRANCH=${GITHUB_REF_NAME}
+          echo GIT_HASH=${GIT_HASH} >> ${GITHUB_ENV}
+          echo GIT_BRANCH=${GIT_BRANCH} >> ${GITHUB_ENV}
+
+          mkdir -p /tmp/ccache
+          ln -s /tmp/ccache ${HOME}/.ccache
+
+          NAME=${{inputs.platform}}
+          bash builder.sh ${NAME}
+          cd openipc
+
+          TIME=$(date -d @${SECONDS} +%M:%S)
+          echo TIME=${TIME} >> ${GITHUB_ENV}
+          COMMON=$(echo ${NAME} | awk -F_ '{print NF-1}')
+
+          NORFW=$(find output/images -name openipc*nor*)
+          if [ ! -z ${NORFW} ]; then
+            if [ ${COMMON} -eq 1 ]; then
+              echo NORFW=openipc/${NORFW} >> ${GITHUB_ENV}
+            else
+              mv ${NORFW} ../${NAME}-nor.tgz
+              echo NORFW=${NAME}-nor.tgz >> ${GITHUB_ENV}
+            fi
+          fi
+
+          NANDFW=$(find output/images -name openipc*nand*)
+          if [ ! -z ${NANDFW} ]; then
+            if [ ${COMMON} -eq 1 ]; then
+              echo NANDFW=openipc/${NANDFW} >> ${GITHUB_ENV}
+            else
+              mv ${NANDFW} ../${NAME}-nand.tgz
+              echo NANDFW=${NAME}-nand.tgz >> ${GITHUB_ENV}
+            fi
+          fi
+
+          if [ -z ${NORFW} ] && [ -z ${NANDFW} ]; then
+            exit 1
+          fi
+
+      - name: Upload firmware
+        if: env.NORFW || env.NANDFW
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{env.TAG_NAME}}
+          files: |
+            ${{env.NORFW}}
+            ${{env.NANDFW}}


### PR DESCRIPTION
## Summary

- Adds a `build-one` workflow that takes a full platform name (e.g. `hi3518ev200_lite_switcam-hs303-v2`) and runs only that build
- Mirrors the [`build-one` workflow](https://github.com/OpenIPC/firmware/blob/master/.github/workflows/build-one.yml) already in OpenIPC/firmware
- Closes the gap that the existing matrix-of-everything `Build` workflow's optional `platform` input filters by SoC prefix only (`cut -d_ -f1`), so it can't be used to test a single device profile in isolation

## Test plan

- [ ] Trigger the workflow via the Actions tab with `platform=hi3518ev200_lite_switcam-hs303-v2` and confirm it builds and uploads the artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)