### PR TITLE
ci/build-one: accept arbitrary commit input; publish to nightly-bisect-* tag

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -5,18 +5,44 @@ on:
       platform:
         description: 'Platform to build (e.g. hi3518ev200_lite_switcam-hs303-v2)'
         required: true
-
-env:
-  TAG_NAME: latest
+      commit:
+        description: 'Commit SHA to build (optional; defaults to current branch HEAD). Use this from `git bisect run` or for one-off historic rebuilds.'
+        required: false
 
 jobs:
+  resolve:
+    name: Resolve commit
+    runs-on: ubuntu-latest
+    outputs:
+      ref:       ${{ steps.r.outputs.ref }}
+      short_sha: ${{ steps.r.outputs.short_sha }}
+      tag_name:  ${{ steps.r.outputs.tag_name }}
+    steps:
+      - id: r
+        run: |
+          REF="${{ inputs.commit }}"
+          [ -z "$REF" ] && REF="${{ github.sha }}"
+          SHORT="$(printf '%s' "$REF" | cut -c1-7)"
+          if [ -n "${{ inputs.commit }}" ]; then
+            TAG="nightly-bisect-${SHORT}"
+          else
+            TAG="nightly-bisect-${SHORT}-$(date -u +%Y%m%d%H%M%S)"
+          fi
+          echo "ref=$REF"               >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT"       >> "$GITHUB_OUTPUT"
+          echo "tag_name=$TAG"          >> "$GITHUB_OUTPUT"
+          echo "Building ${{ inputs.platform }} at $REF -> release tag $TAG"
+
   buildroot:
     name: Firmware (${{inputs.platform}})
+    needs: resolve
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
 
       - name: Prepare firmware
         run: |
@@ -30,6 +56,10 @@ jobs:
           key: ${{inputs.platform}}-${{env.CACHE_DATE}}
 
       - name: Build firmware
+        env:
+          BUILD_ID:       ${{ needs.resolve.outputs.tag_name }}
+          BUILD_SHA:      ${{ needs.resolve.outputs.ref }}
+          BUILD_PLATFORM: ${{ inputs.platform }}
         run: |
           export GIT_HASH=$(git rev-parse --short ${GITHUB_SHA})
           export GIT_BRANCH=${GITHUB_REF_NAME}
@@ -40,7 +70,20 @@ jobs:
           ln -s /tmp/ccache ${HOME}/.ccache
 
           NAME=${{inputs.platform}}
-          bash builder.sh ${NAME}
+          # Retry budget for transient upstream toolchain/CDN flakes
+          # (matches master.yml + OpenIPC/firmware/build-one.yml).
+          backoffs="30 60 120 300 600 1200"
+          attempt=1
+          for sleep_for in $backoffs ""; do
+            bash builder.sh ${NAME} && break
+            if [ -z "$sleep_for" ]; then
+              echo "::error::build failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "::warning::attempt ${attempt} failed, retrying after ${sleep_for}s"
+            sleep "$sleep_for"
+            attempt=$((attempt + 1))
+          done
           cd openipc
 
           TIME=$(date -d @${SECONDS} +%M:%S)
@@ -75,7 +118,13 @@ jobs:
         if: env.NORFW || env.NANDFW
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{env.TAG_NAME}}
+          tag_name: ${{ needs.resolve.outputs.tag_name }}
+          prerelease: true
+          body: |
+            sha=${{ needs.resolve.outputs.ref }}
+            short=${{ needs.resolve.outputs.short_sha }}
+            platform=${{ inputs.platform }}
+            one_off=true
           files: |
             ${{env.NORFW}}
             ${{env.NANDFW}}


### PR DESCRIPTION
## Summary

PR-Bld-C of three in the mirror of OpenIPC/firmware's nightly redesign. Mirrors OpenIPC/firmware#2116. Tiny CI-only change: `build-one.yml` gains an optional `commit` workflow_dispatch input, enabling `git bisect run` to drive sub-nightly granularity rebuilds.

### What changes

- New optional input `commit:` (SHA). When set, checkout pulls that ref.
- New `resolve` job computes the upload tag once and threads it via job outputs:
  - With `commit`: `nightly-bisect-<short>` (deterministic per commit, prerelease)
  - Without `commit`: `nightly-bisect-<short>-<UTC ts>` (so repeated one-offs of the same HEAD don't collide).
- Upload becomes prerelease with a structured body (`sha=`/`short=`/`platform=`/`one_off=true`).
- Retry budget bumped to match PR-Bld-A (`30 60 120 300 600 1200`).
- BUILD_ID / BUILD_SHA / BUILD_PLATFORM env at the build step (forward-compat with Phase 3 of the mirror plan).
- Drops dead workflow-level `env: TAG_NAME: latest`.

### Tag namespace separation

`nightly-bisect-*` is deliberately distinct from `nightly-YYYYMMDD-<short>` (the dated nightlies produced by `master.yml` after #91):

- `enrich_manifest.py` (PR-Bld-B, #92) filters strictly on `^nightly-[0-9]{8}-[0-9a-f]{7}$`, so `nightly-bisect-*` releases **never enter** `manifest.{json,flat}`.
- `cleanup.yml` (PR-Bld-B) uses the same regex, so the 90-build retention sweep **leaves them alone**. One-off bisect builds persist until you delete them manually.

### Use it

```sh
# Single platform, single commit:
gh workflow run build-one.yml -f platform=gk7205v200_fpv_caddx-fly -f commit=<sha>
```

### Test plan

- [ ] CI passes (YAML parse).
- [ ] After merge, dispatch with `platform=<x> -f commit=<sha>` → builds that ref, publishes to `nightly-bisect-<short>` (deterministic).
- [ ] Dispatch with `platform=<x>` and no commit → builds HEAD, publishes to `nightly-bisect-<short>-<ts>`.
- [ ] After PR-Bld-A + PR-Bld-B both merge: verify dated nightly index on gh-pages is unchanged (no `nightly-bisect-*` entries in `manifest.flat`).

### See also

- Companion plan: `~/.claude/plans/mirror-nightly-redesign-to-builder.md`.
- Sibling PRs: #91 (PR-Bld-A), #92 (PR-Bld-B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)