### PR TITLE
build-one: add firmware_ref input for cross-repo bisect

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -6,7 +6,10 @@ on:
         description: 'Platform to build (e.g. hi3518ev200_lite_switcam-hs303-v2)'
         required: true
       commit:
-        description: 'Commit SHA to build (optional; defaults to current branch HEAD). Use this from `git bisect run` or for one-off historic rebuilds.'
+        description: 'Builder commit SHA to build (optional; defaults to current branch HEAD). Use this from `git bisect run` or for one-off historic rebuilds.'
+        required: false
+      firmware_ref:
+        description: 'OpenIPC/firmware ref (SHA/tag/branch) to clone — for cross-repo bisect of size/regression issues. Defaults to firmware HEAD.'
         required: false
 
 jobs:
@@ -60,6 +63,7 @@ jobs:
           BUILD_ID:       ${{ needs.resolve.outputs.tag_name }}
           BUILD_SHA:      ${{ needs.resolve.outputs.ref }}
           BUILD_PLATFORM: ${{ inputs.platform }}
+          OPENIPC_FW_REV: ${{ inputs.firmware_ref }}
         run: |
           export GIT_HASH=$(git rev-parse --short ${GITHUB_SHA})
           export GIT_BRANCH=${GITHUB_REF_NAME}

--- a/builder.sh
+++ b/builder.sh
@@ -124,9 +124,18 @@ echo_c 33 "\nUpdating Builder"
 git pull
 
 rm -rf openipc
+# OPENIPC_FW_REV pins firmware to a specific ref (branch, tag, or SHA) for
+# cross-repo bisect of size/regression issues — set by build-one.yml's
+# firmware_ref input. When unset, clones HEAD of master as before.
 if [ ! -d "$FIRMWARE_DIR" ]; then
-    echo_c 33 "\nDownloading Firmware"
-    git clone --depth=1 https://github.com/OpenIPC/firmware.git "$FIRMWARE_DIR"
+    if [ -n "$OPENIPC_FW_REV" ]; then
+        echo_c 33 "\nDownloading Firmware @ ${OPENIPC_FW_REV}"
+        git clone https://github.com/OpenIPC/firmware.git "$FIRMWARE_DIR"
+        git -C "$FIRMWARE_DIR" checkout "$OPENIPC_FW_REV"
+    else
+        echo_c 33 "\nDownloading Firmware"
+        git clone --depth=1 https://github.com/OpenIPC/firmware.git "$FIRMWARE_DIR"
+    fi
     cd "$FIRMWARE_DIR"
 else
     echo_c 33 "\nUpdating Firmware"


### PR DESCRIPTION
## Summary

Adds a clean mechanism to pin OpenIPC/firmware to a specific ref (SHA / tag / branch) when running build-one.yml. Two-file change.

### What's new

```sh
gh workflow run build-one.yml \
  -f platform=hi3516ev200_fpv \
  -f firmware_ref=<sha-or-tag-or-branch>
```

- New optional input `firmware_ref` on `build-one.yml`.
- Workflow exports `OPENIPC_FW_REV` env to the Build firmware step.
- `builder.sh` honours `$OPENIPC_FW_REV`: when set, does a **full** clone (not `--depth=1`) and `git checkout` to the requested ref. When unset, behaviour is unchanged (shallow clone of master HEAD).

### Immediate motivation

Bisect the +180 KB rootfs growth in `hi3516ev200_fpv` between 2026-05-08 (5016 KB) and 2026-05-24 (5196 KB, **76 KB over the 5120 KB partition limit**). The first builder cron under the new mirror code surfaced this as a real content regression; suspect is recent `hisilicon-opensdk` bumps that brought in source-built sensor drivers for ev200, but no single commit accounts for the full growth. Bisect across `HISILICON_OPENSDK_VERSION` values via this input will pinpoint which bump pushed us over.

See kaeru note `hi3516ev200-ev300-fpv-rootfs-size-overflow-2026-05-24` for the full investigation.

### Generally useful long after this incident

- Reproducing user-reported regressions at a specific firmware tag.
- Locking builds to a known-good firmware revision when builder is ahead of firmware.
- Future cross-repo bisects of any kind.

### Test plan

- [ ] CI parses YAML.
- [ ] After merge: `gh workflow run build-one.yml -f platform=hi3516ev200_fpv -f firmware_ref=7fc6cda4` (firmware tip ~3 weeks ago) → builder.sh logs `Downloading Firmware @ 7fc6cda4` and the build proceeds at that ref.
- [ ] Same command without `firmware_ref` → behaviour unchanged (shallow clone of master HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)