### PR TITLE
xg521: update device override for 60fps→high-fps rename in firmware

### DIFF
--- a/devices/gk7202v300_lite_xg521/general/package/goke-osdrv-gk7205v200/goke-osdrv-gk7205v200.mk
+++ b/devices/gk7202v300_lite_xg521/general/package/goke-osdrv-gk7205v200/goke-osdrv-gk7205v200.mk
@@ -31,8 +31,8 @@ define GOKE_OSDRV_GK7205V200_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/etc/sensors/WDR
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensors/WDR $(GOKE_OSDRV_GK7205V200_PKGDIR)/files/sensor/config/WDR/*.ini
 
-	$(INSTALL) -m 755 -d $(TARGET_DIR)/etc/sensors/60fps
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensors/60fps $(GOKE_OSDRV_GK7205V200_PKGDIR)/files/sensor/config/60fps/*.ini
+	$(INSTALL) -m 755 -d $(TARGET_DIR)/etc/sensors/high-fps
+	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensors/high-fps $(GOKE_OSDRV_GK7205V200_PKGDIR)/files/sensor/config/high-fps/*.ini
 
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/etc/sensors/iq
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensors/iq $(GOKE_OSDRV_GK7205V200_PKGDIR)/files/sensor/iq/imx307.ini


### PR DESCRIPTION
## Summary

The xg521 device-specific override at `devices/gk7202v300_lite_xg521/general/package/goke-osdrv-gk7205v200/goke-osdrv-gk7205v200.mk` references `/etc/sensors/60fps` and `files/sensor/config/60fps/*.ini`. OpenIPC/firmware#2090 (2026-05-13, "IMX335 companion to openhisilicon #99") renamed the upstream directory `60fps/` → `high-fps/`. Every cron build of `gk7202v300_lite_xg521` since then has failed:

```
/usr/bin/install: cannot stat 'general/package/goke-osdrv-gk7205v200//files/sensor/config/60fps/*.ini': No such file or directory
```

Two-line fix: change both install rules to use `high-fps`. Target install path moves from `/etc/sensors/60fps` → `/etc/sensors/high-fps` to match the rest of the V4 sensor presets.

## Notes

- The matching entry in `devices/gk7202v300_lite_xg521/general/scripts/excludes/gk7202v300_lite.list` (`/etc/sensors/60fps/720p_imx307_i2c_2l.ini`) is now stale, but harmless — `rootfs_script.sh` uses `rm -f` (no-op on missing path). Cleanup can be a follow-up.
- Other Goke device overlays (gk7205v200_lite_*, gk7205v210_lite_*, gk7205v300_lite_*, etc.) have the same exclude-list staleness but **no broken install rule**. They're not affected by this bug. xg521 is the only one with its own `.mk` override that diverged.

## Test plan

- [ ] CI passes (YAML/Makefile syntactic only — no buildable code change reachable via PR triggers).
- [ ] After merge, `gh workflow run build-one.yml -f platform=gk7202v300_lite_xg521` produces a successful build.
- [ ] Next builder cron `gk7202v300_lite_xg521` matrix entry passes; result lands in the `https://openipc.github.io/builder/manifest.flat` index for the first time since 2026-05-13.

## See also

- Kaeru node `hi3516ev200-ev300-fpv-rootfs-size-overflow-2026-05-24` for the broader sweep of 2026-05-13 sensor-work fallout (also includes the unrelated fpv variant rootfs overflow).
- OpenIPC/firmware#2090 — the upstream rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)