### PR TITLE
ci: cache Buildroot dl/ at /tmp/builder-dl (mirrors firmware's dl cache)

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -58,6 +58,15 @@ jobs:
           path: /tmp/ccache
           key: ${{inputs.platform}}-${{env.CACHE_DATE}}
 
+      # See master.yml for the rationale — builder.sh rm -rf's openipc/
+      # every run, so dl/ has to live outside via BR2_DL_DIR.
+      - name: Setup dl cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/builder-dl
+          key: builder-dl-${{env.CACHE_DATE}}
+          restore-keys: builder-dl-
+
       - name: Build firmware
         env:
           BUILD_ID:       ${{ needs.resolve.outputs.tag_name }}
@@ -72,6 +81,9 @@ jobs:
 
           mkdir -p /tmp/ccache
           ln -s /tmp/ccache ${HOME}/.ccache
+
+          mkdir -p /tmp/builder-dl
+          export BR2_DL_DIR=/tmp/builder-dl
 
           NAME=${{inputs.platform}}
           # Retry budget for transient upstream toolchain/CDN flakes

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -195,6 +195,30 @@ jobs:
           path: /tmp/ccache
           key: ${{matrix.platform}}-${{env.CACHE_DATE}}
 
+      # builder.sh does `rm -rf openipc` at the top of every run to force a
+      # clean re-clone of OpenIPC/firmware, which also nukes the default
+      # `openipc/output/dl/` directory Buildroot uses for downloaded source
+      # tarballs. Without a cache, every cron run re-downloads ~1-3 GB of
+      # tarballs from upstream mirrors — and any one of them randomly
+      # failing (e.g. cgit `snapshot/` URLs that regenerate tarballs per
+      # request with shifting sha256, like wireguard-tools on
+      # git.zx2c4.com) takes down the matrix entry for that board. See
+      # kaeru wireguard-zx2c4-tarball-regeneration-hash-drift for the
+      # specific incident this caching addresses.
+      #
+      # Cache to /tmp/builder-dl (outside the openipc/ tree so builder.sh's
+      # rm -rf doesn't touch it) and point Buildroot at it via BR2_DL_DIR
+      # env var (honored per Buildroot manual section "Location of source
+      # tarballs"). Mirrors OpenIPC/firmware/.github/workflows/build.yml's
+      # output/dl cache, adapted for builder's clean-clone behavior.
+      - name: Setup dl cache
+        if: env.RUN
+        uses: actions/cache@v4
+        with:
+          path: /tmp/builder-dl
+          key: builder-dl-${{env.CACHE_DATE}}
+          restore-keys: builder-dl-
+
       - name: Build firmware
         if: env.RUN
         run: |
@@ -205,6 +229,9 @@ jobs:
 
           mkdir -p /tmp/ccache
           ln -s /tmp/ccache ${HOME}/.ccache
+
+          mkdir -p /tmp/builder-dl
+          export BR2_DL_DIR=/tmp/builder-dl
 
           NAME=${{matrix.platform}}
           # Retry budget for transient upstream toolchain/CDN flakes


### PR DESCRIPTION
## Summary

`OpenIPC/firmware/.github/workflows/build.yml` caches `output/dl` across runs. Once any board has cached the canonical tarball for a package, all subsequent runs reuse it regardless of whether the upstream is healthy that day. **builder had no equivalent**, so every cron fully re-downloads ~1-3 GB of tarballs, exposing every matrix entry to whatever transient upstream failure is happening right now.

Hit hard 2026-05-24 by `wireguard-tools-1.0.20210914.tar.xz`: served from a cgit `snapshot/` URL on git.zx2c4.com that regenerates the tarball per-request with shifting sha256 (verified by HEAD probe — `last-modified` matches request time), and `sources.buildroot.net` also served drifted bytes. 93 builder boards enable wireguard; on any given cron a few of them roll snake-eyes on the download and fail with:

```
ERROR: wireguard-tools-1.0.20210914.tar.xz has wrong sha256 hash:
ERROR: expected: 97ff31489217bb265b7ae850d3d0f335ab07d2652ba1feec88b734bc96bd05ac
ERROR: got     : 942ed32d1d6631932c82ff86c91ae8428d4c90bfec231a14ebdf6c29f068e60b
```

See kaeru `wireguard-zx2c4-tarball-regeneration-hash-drift` for the full diagnosis.

## What this PR does

Mirrors firmware's pattern with one wrinkle: `builder.sh` does `rm -rf openipc` at the top of every run to force a clean re-clone of firmware. That would nuke `openipc/output/dl/` if we cached the default path. Cache **`/tmp/builder-dl`** instead (outside the openipc tree) and point Buildroot at it via the `BR2_DL_DIR` env var, honored per Buildroot manual section "Location of source tarballs".

Same restore + save lifecycle as firmware's; same monthly key shape (`builder-dl-<MM>` to keep them in distinct cache namespaces). Both `master.yml` and `build-one.yml` get the treatment so single-board dispatches share the cache pool.

## Effect

| Run | Behavior |
|---|---|
| First cron after merge | Full download as usual; warms `/tmp/builder-dl` |
| Subsequent crons | Instant cache hit for unchanged packages; re-download only on version bumps. **Wireguard-roulette failure mode disappears** once cache is populated. |

## Test plan

- [ ] CI passes the YAML parse (builder has no PR-trigger CI).
- [ ] After merge, dispatch `build-one.yml -f platform=gk7205v300_lite_vixand-ivg-g6s-w` (the canary that was failing on the wireguard hash roulette) — first run downloads & populates cache; second run hits cache and succeeds even if upstream is misbehaving.
- [ ] Tonight's cron warms cache for the full ~100-board matrix; next cron after that uses cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)