### PR TITLE
ci: always rebuild on schedule (drop builder-HEAD-only dedupe)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,15 +28,16 @@ jobs:
           SHORT=$(git rev-parse --short HEAD)
           BUILD_ID="nightly-$(date -u +%Y%m%d)-${SHORT}"
           BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          PREV=$(gh release view nightly --json body -q .body 2>/dev/null \
-                  | sed -n 's/^sha=//p' | head -1 || true)
-          if [ "${{ github.event_name }}" = "schedule" ] && [ "$PREV" = "$HEAD" ]; then
-            echo "Skip: HEAD ($HEAD) already published as the latest nightly."
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Build: $BUILD_ID (event=${{ github.event_name }}, prev=$PREV)"
-            echo "should_build=true"  >> "$GITHUB_OUTPUT"
-          fi
+          # Nightly rebuilds unconditionally on schedule. builder.sh re-clones
+          # OpenIPC/firmware at HEAD on every run, so the relevant inputs are
+          # mostly outside this repo (firmware HEAD, toolchain release, kernel
+          # tarball, vendor osdrv, individual package upstreams). The previous
+          # gate skipped when only this repo's HEAD matched the last published
+          # nightly, which made upstream fixes (e.g. an openhisilicon mipi_rx
+          # regression fix that lands in firmware) invisible to users until
+          # something here happened to change. Always build on schedule.
+          echo "Build: $BUILD_ID (event=${{ github.event_name }})"
+          echo "should_build=true"  >> "$GITHUB_OUTPUT"
           echo "head_sha=$HEAD"      >> "$GITHUB_OUTPUT"
           echo "short_sha=$SHORT"    >> "$GITHUB_OUTPUT"
           echo "build_id=$BUILD_ID"  >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The preflight gate in `.github/workflows/master.yml` skipped scheduled runs whenever this repo's HEAD matched the SHA recorded in the previous `nightly` release body. That dedupe key ignores every upstream input the build actually depends on — `OpenIPC/firmware` HEAD, the toolchain release, the kernel tarball, the vendor osdrv packages, individual buildroot package upstreams — all of which move independently of this repo. `builder.sh` re-clones `OpenIPC/firmware` fresh on every run, so those upstream changes *do* land in nightlies even when this repo is quiet.

Result: when an upstream fix lands but this repo is unchanged, the next scheduled nightly is skipped entirely and the previous (stale) artifact stays the `latest` for end users.

## Concrete incident (closing the loop)

On 2026-05-26 `OpenIPC/firmware` bumped its `hisilicon-opensdk` pin to `b958db4`, which contains the V4 mipi_rx vsync IRQ fix ([openhisilicon#195](https://github.com/OpenIPC/openhisilicon/pull/195), closes openhisilicon#194 — torn frames / `Timeout from venc channel 0` on `hi3516ev200`, `gk7205v200`, `gk7205v210`, `gk7205v300`, `hi3516ev300` hardware).

The next builder nightly (2026-05-27 07:00 UTC, run `26496070801`) ran with this repo unchanged since 2026-05-25, so the preflight gate matched and skipped the entire Firmware matrix (`- Firmware in 0s`). Field cameras kept pulling the stale `latest` release asset and kept showing the regression after sysupgrade. Verified on a `gk7205v210_lite_vixand-ivg-g4h` board:

- `BUILD_ID=nightly-20260526-ee40da8`
- kernel built `Tue May 26 06:46 UTC` — ~8 h before the opensdk bump merged at 14:47 UTC
- `/sys/module/open_mipi_rx/srcversion = 8EF923DF907C1F7F3C6898E` — the exact pre-fix fingerprint from openhisilicon#195's verification table
- `lsmod` showed `open_openipc_frame_ts` still depended on by `open_mipi_rx` (call-site survived compilation)

## Approach

A cross-input dedupe key would be possible (firmware HEAD + toolchain URL hash + kernel tarball hash + …) but enumerates every upstream this build pulls and is fragile. Simpler and correct: **scheduled nightlies always build**. The cron exists because the upstreams move nightly; that's the whole point. `workflow_dispatch` was already unconditional and is unaffected.

## Test plan

- [x] Workflow YAML still parses
- [ ] Next scheduled nightly (`0 3 * * *` UTC) runs the Firmware matrix even though this repo HEAD is unchanged
- [ ] Resulting `gk7205v210_lite_vixand-ivg-g4h-nor.tgz` in the `latest` release is built against post-`b958db4` firmware
- [ ] Re-flashed camera: `cat /sys/module/open_mipi_rx/srcversion` ≠ `8EF923DF907C1F7F3C6898E`, and `open_mipi_rx` no longer listed under `open_openipc_frame_ts` in `lsmod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)