### PR TITLE
ci: drop sizes.json URLs from manifest.json (CORS-blocked in browsers)

### DIFF
--- a/.github/scripts/enrich_manifest.py
+++ b/.github/scripts/enrich_manifest.py
@@ -41,15 +41,6 @@ TAG_RE = re.compile(r"^nightly-(\d{8})-([0-9a-f]{7})$")
 COMPOUND_RE = re.compile(r"^(?P<platform>[a-z0-9]+_[a-z0-9]+_[a-z0-9_.-]+)-(?P<flash>nor|nand)\.tgz$")
 SIMPLE_RE   = re.compile(r"^openipc\.(?P<soc>[^.]+)-(?P<flash>nor|nand)-(?P<variant>\w+)\.tgz$")
 
-# Per-platform size report sidecar (PR #97, mirrors firmware PR #2166).
-# Compound form is renamed in master.yml to `sizes.<NAME>.json` so two
-# compound devices sharing `<soc>_<variant>` don't collide on upload;
-# simple form keeps firmware's `sizes.<soc>-<variant>.json` shape.
-# Compound is tried first because `[^._-]+` in simple would otherwise
-# accept the underscore-laden compound form too.
-SIZES_COMPOUND_RE = re.compile(r"^sizes\.(?P<platform>[a-z0-9]+_[a-z0-9]+_[a-z0-9_.-]+)\.json$")
-SIZES_SIMPLE_RE   = re.compile(r"^sizes\.(?P<soc>[^._-]+)-(?P<variant>\w+)\.json$")
-
 # Retry budget for transient GitHub API failures (mirrors firmware/#2129).
 GH_RETRY_DELAYS = (0, 5, 15, 40)
 
@@ -116,17 +107,6 @@ def parse_asset(name: str) -> tuple[str, str] | None:
     return None
 
 
-def parse_sizes(name: str) -> str | None:
-    """Returns the platform_key for a sizes.*.json sidecar, or None."""
-    m = SIZES_COMPOUND_RE.match(name)
-    if m:
-        return m.group("platform")
-    m = SIZES_SIMPLE_RE.match(name)
-    if m:
-        return f"{m.group('soc')}_{m.group('variant')}"
-    return None
-
-
 def main() -> None:
     out_dir = Path(sys.argv[1] if len(sys.argv) > 1 else ".")
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -153,19 +133,13 @@ def main() -> None:
         platforms: dict[str, dict[str, dict]] = {}
         for a in info.get("assets") or []:
             parsed = parse_asset(a["name"])
-            if parsed:
-                platform, flash = parsed
-                platforms.setdefault(platform, {})[flash] = {
-                    "url": a["url"],
-                    "size": a["size"],
-                }
+            if not parsed:
                 continue
-            platform = parse_sizes(a["name"])
-            if platform:
-                platforms.setdefault(platform, {})["sizes"] = {
-                    "url": a["url"],
-                    "size": a["size"],
-                }
+            platform, flash = parsed
+            platforms.setdefault(platform, {})[flash] = {
+                "url": a["url"],
+                "size": a["size"],
+            }
         builds.append({
             "id": info["tagName"],
             "sha": sha,
@@ -188,19 +162,11 @@ def main() -> None:
         "# OpenIPC builder build index",
         f"# generated_at={now}",
         "# columns: build_id platform flash size url",
-        "# also: @sizes <build_id> <platform> <size> <url>  (per-platform size report sidecar)",
     ]
     for b in builds:
         for platform, flashes in sorted(b["platforms"].items()):
             for flash, info in sorted(flashes.items()):
-                if flash == "sizes":
-                    continue
                 lines.append(f"{b['id']} {platform} {flash} {info['size']} {info['url']}")
-            sizes = flashes.get("sizes")
-            if sizes:
-                lines.append(
-                    f"@sizes {b['id']} {platform} {sizes['size']} {sizes['url']}"
-                )
     lines.append("# channels")
     for ch, target in manifest["channels"].items():
         lines.append(f"@channel {ch} {target}")


### PR DESCRIPTION
## Summary

Mirror of OpenIPC/firmware#2169. Reverts the manifest-indexing half of
#102 — the part that linked to \`sizes.<plat>.json\` release assets from
\`manifest.json\` and emitted matching \`@sizes\` lines in
\`manifest.flat\`. Those URLs point at
\`github.com/.../releases/download/...\`, which returns no
\`Access-Control-Allow-Origin\` header, so every browser-side fetch was
blocked by CORS. The \"CORS verified\" line in firmware #2166's test
plan was a \`curl -sfL\`, which doesn't enforce CORS — the gap
propagated here and to a downstream PoC that shipped broken.

## What stays

- \`.github/workflows/master.yml\`'s _Build size report_ step and the
  bimodal rename block.
- The \`\${{env.SIZES}}\` line in all three upload steps — release tags
  keep carrying \`sizes.<plat>.json\` (compound: \`sizes.<NAME>.json\`)
  as the canonical artefact, addressable server-side via \`gh release
  download\` and consumable by any CI workflow (no CORS gate there).

## What goes

- \`SIZES_COMPOUND_RE\`, \`SIZES_SIMPLE_RE\`, \`parse_sizes()\` in
  \`.github/scripts/enrich_manifest.py\`.
- The asset-loop branch that recorded \`platforms[<plat>].sizes\`.
- The \`@sizes\` line type in \`manifest.flat\`.

Result: \`enrich_manifest.py\` is bit-for-bit identical to the
pre-#102 state (file hash \`cdf24f4d\`).

## Why not also drop the release-asset upload

Same as the firmware revert: a downstream firmware-explorer rebuild
(separate PR) will run a build-time aggregator that downloads release
assets server-side and bakes the data into a static site, avoiding
the cross-origin fetch entirely. Keeping releases as the canonical
artefact source means no duplication across stores.

## On-device impact

None. The on-device sysupgrade reads positional 4-column lines from
\`manifest.flat\` and skips \`@\`-prefixed directives it doesn't
recognise. Dropping \`@sizes\` lines is a strict superset of what it
already ignored.

## Test plan

- [x] \`python3 -m py_compile .github/scripts/enrich_manifest.py\` — syntax OK.
- [x] Diff confirmed bit-for-bit revert of #102's manifest changes
      (file hash matches pre-PR state).
- [ ] Merge sequencing: land firmware #2169 first so both manifests
      drop \`sizes\` URLs together. Builder consuming a firmware
      branch isn't affected because the revert is local to each
      \`enrich_manifest.py\`.
- [ ] Post-merge: the next \`manifest\` workflow run drops the \`sizes\`
      blocks from \`builds[].platforms.*\` in
      https://openipc.github.io/builder/manifest.json and stops
      emitting \`@sizes\` lines in
      https://openipc.github.io/builder/manifest.flat .

🤖 Generated with [Claude Code](https://claude.com/claude-code)