### PR TITLE
ci: re-fetch moving-ref package downloads each build (fixes stale webui)

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -67,6 +67,16 @@ jobs:
           key: builder-dl-${{env.CACHE_DATE}}
           restore-keys: builder-dl-
 
+      - name: Refresh moving-ref package downloads
+        run: |
+          # The monthly builder-dl cache freezes moving-ref downloads (VERSION = HEAD /
+          # branch, or the majestic-webui `dist` release asset) under a constant
+          # <pkg>-<ref>.tar.gz filename, so buildroot keeps reusing a stale tarball.
+          # Drop them so it re-fetches the current ref each run. See master.yml.
+          find /tmp/builder-dl -type f \
+            \( -name '*-HEAD.tar.gz' -o -name '*-master.tar.gz' -o -name '*-main.tar.gz' -o -name '*-dist.tar.gz' \) \
+            -print -delete 2>/dev/null || true
+
       - name: Build firmware
         env:
           BUILD_ID:       ${{ needs.resolve.outputs.tag_name }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -220,6 +220,24 @@ jobs:
           key: builder-dl-${{env.CACHE_DATE}}
           restore-keys: builder-dl-
 
+      - name: Refresh moving-ref package downloads
+        if: env.RUN
+        run: |
+          # builder caches BR2_DL_DIR (/tmp/builder-dl) under a monthly key
+          # (date +%m) and actions/cache only saves on a key miss, so the first build
+          # of the month freezes it for weeks. Packages pinned to a moving ref
+          # (VERSION = HEAD / branch, or the majestic-webui `dist` release asset)
+          # download as a constant <pkg>-<ref>.tar.gz, so buildroot keeps reusing the
+          # stale tarball — even though builder re-clones firmware HEAD each run for
+          # freshness. (Empirically: a 06-14 builder nightly shipped a ~2-week-old
+          # majestic-webui — full bootstrap.min.css, no mj-settings.js — while the
+          # firmware nightly shipped the current UI.) Drop those archives so buildroot
+          # re-fetches the current ref each run. Content-addressed packages
+          # (S3 / semver / SHA pins) keep their cache.
+          find /tmp/builder-dl -type f \
+            \( -name '*-HEAD.tar.gz' -o -name '*-master.tar.gz' -o -name '*-main.tar.gz' -o -name '*-dist.tar.gz' \) \
+            -print -delete 2>/dev/null || true
+
       - name: Build firmware
         if: env.RUN
         run: |


### PR DESCRIPTION
## Problem (empirically confirmed)

`builder` caches `BR2_DL_DIR` (`/tmp/builder-dl`) under a **monthly** key
(`builder-dl-$(date +%m)`), and `actions/cache` only **saves on a key miss** — so the
first build of the month freezes the download dir for weeks. Packages pinned to a
**moving ref** (`VERSION = HEAD` / a branch, or the `majestic-webui` rolling `dist`
release asset) download as a constant `<pkg>-<ref>.tar.gz`, so buildroot finds the
frozen tarball and never re-fetches — **defeating the clean firmware-HEAD re-clone that
builder does on every run specifically for freshness.**

I verified this on real nightly assets:

| `OPENIPC_VERSION=2.6.06.14`, both built **2026-06-14** | `bootstrap.min.css` | settings JS | webui age |
|---|---|---|---|
| firmware nightly (`ssc335de`) | 101 KB (purged) | `mj-settings.js` present | **current** |
| builder nightly (`gk7202v300`) | **232 KB (full)** | **`mj-settings.js` absent** | **~2 weeks stale** |

Same firmware source on both; the only difference is firmware has this cache-bust and builder doesn't.

## Fix

A `Refresh moving-ref package downloads` step right after `Setup dl cache` in both
`master.yml` and `build-one.yml`, dropping `*-{HEAD,master,main,dist}.tar.gz` from
`/tmp/builder-dl` before the build so buildroot re-fetches the current ref. Content-
addressed packages (S3 / semver / SHA pins) keep their cache. Mirrors the same fix
already in `OpenIPC/firmware`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)