### PR TITLE
ci: evict majestic's moving S3 tarball from the dl cache too

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -69,12 +69,14 @@ jobs:
 
       - name: Refresh moving-ref package downloads
         run: |
-          # The monthly builder-dl cache freezes moving-ref downloads (VERSION = HEAD /
-          # branch, or the majestic-webui `dist` release asset) under a constant
-          # <pkg>-<ref>.tar.gz filename, so buildroot keeps reusing a stale tarball.
-          # Drop them so it re-fetches the current ref each run. See master.yml.
-          find /tmp/builder-dl -type f \
-            \( -name '*-HEAD.tar.gz' -o -name '*-master.tar.gz' -o -name '*-main.tar.gz' -o -name '*-dist.tar.gz' \) \
+          # The monthly builder-dl cache freezes moving-ref downloads under a constant
+          # filename, so buildroot keeps reusing a stale tarball. Drop them so it
+          # re-fetches the current ref each run. See master.yml for the rationale.
+          # Covers both the dash form (<pkg>-<ref>.tar.gz, e.g. majestic-webui-dist) and
+          # the dot form (<pkg>.<ref>.tar.bz2, e.g. majestic.t31.lite.master from S3 —
+          # a moving build with no .hash, NOT a content-addressed pin).
+          find /tmp/builder-dl -type f -regextype posix-extended \
+            -regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)' \
             -print -delete 2>/dev/null || true
 
       - name: Build firmware

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -225,17 +225,20 @@ jobs:
         run: |
           # builder caches BR2_DL_DIR (/tmp/builder-dl) under a monthly key
           # (date +%m) and actions/cache only saves on a key miss, so the first build
-          # of the month freezes it for weeks. Packages pinned to a moving ref
-          # (VERSION = HEAD / branch, or the majestic-webui `dist` release asset)
-          # download as a constant <pkg>-<ref>.tar.gz, so buildroot keeps reusing the
-          # stale tarball — even though builder re-clones firmware HEAD each run for
-          # freshness. (Empirically: a 06-14 builder nightly shipped a ~2-week-old
-          # majestic-webui — full bootstrap.min.css, no mj-settings.js — while the
-          # firmware nightly shipped the current UI.) Drop those archives so buildroot
-          # re-fetches the current ref each run. Content-addressed packages
-          # (S3 / semver / SHA pins) keep their cache.
-          find /tmp/builder-dl -type f \
-            \( -name '*-HEAD.tar.gz' -o -name '*-master.tar.gz' -o -name '*-main.tar.gz' -o -name '*-dist.tar.gz' \) \
+          # of the month freezes it for weeks. Packages pinned to a moving ref keep a
+          # constant download filename, so buildroot reuses the stale tarball — even
+          # though builder re-clones firmware HEAD each run for freshness. Two forms:
+          #   - dash:  <pkg>-<ref>.tar.gz   e.g. majestic-webui-dist.tar.gz
+          #   - dot:   <pkg>.<ref>.tar.bz2  e.g. majestic.t31.lite.master.tar.bz2
+          # The dot form is majestic's S3 tarball: it LOOKS S3-pinned but is a moving
+          # `master` build re-uploaded every majestic CI run, with no .hash to force a
+          # refetch — so it must be evicted too. (Empirically: a 06-14 nightly shipped a
+          # ~2-week-old majestic-webui; later a t31 lite image shipped a pre-x-groups
+          # majestic against the current webui — "No settings groups in schema".) Drop
+          # both forms so buildroot re-fetches the current ref. Only genuinely
+          # content-addressed tarballs (semver / SHA in the name) keep their cache.
+          find /tmp/builder-dl -type f -regextype posix-extended \
+            -regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)' \
             -print -delete 2>/dev/null || true
 
       - name: Build firmware


### PR DESCRIPTION
## Problem

A t31 lite image (`t31_lite_xiaomi-mjsxj03hl-nor.tgz`) shipped a **stale majestic** (`master+2c8fc00`, 2026-05-24) against a current webui, so the Majestic Settings page dies with **"No settings groups in schema."** Since webui #68 the settings tabs come only from majestic's `x-groups` schema manifest, which majestic emits only since 2026-06-12 (`ab639ad3`). The bundled majestic predated it.

## Root cause

PR #105's *"Refresh moving-ref package downloads"* step evicts `*-{HEAD,master,main,dist}.tar.gz`. That covers the webui dist (`majestic-webui-dist.tar.gz`) but **not majestic**, which downloads from S3 as:

```
majestic.<family>.<variant>.master.tar.bz2     # e.g. majestic.t31.lite.master.tar.bz2
```

— a **dot** separator, **`.tar.bz2`**, on the S3 host the old pattern deliberately spared as "content-addressed". But that S3 object is a **moving `master` build**, re-uploaded on every majestic CI run, with **no `.hash`** to force a refetch. So it stayed frozen in the monthly `builder-dl` cache while the webui refreshed — the exact desync.

(Verified: the live S3 `majestic.t31.lite.master.tar.bz2` is Last-Modified 2026-06-25 and **does** contain the `x-groups` manifest. So the bucket is fresh; only the build cache was stale. PR #105 fixed the *prior* polarity — stale webui — not this one.)

## Fix

Broaden the eviction to a regex covering both `-ref` and `.ref` separators across gz/bz2/xz:

```
find <dl> -type f -regextype posix-extended \
  -regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)' \
  -print -delete
```

Evicts `majestic.*.master.tar.bz2` **and** `majestic-webui-dist.tar.gz`, while sparing semver/SHA-pinned tarballs (verified against samples, incl. the tricky `mastermind-2.0.tar.gz`). Applied to both `build-one.yml` and `master.yml`.

> The same too-narrow pattern exists in `OpenIPC/firmware` (`build.yml` + `build-one.yml`) and wants the identical change in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)