### PR TITLE
package: general waybeam encoder package for Infinity6E and Infinity6C

### DIFF
--- a/package/waybeam/Config.in
+++ b/package/waybeam/Config.in
@@ -1,0 +1,22 @@
+config BR2_PACKAGE_WAYBEAM
+	bool "waybeam"
+	depends on BR2_TOOLCHAIN_HAS_THREADS
+	depends on BR2_PACKAGE_SIGMASTAR_OSDRV_INFINITY6E || \
+		BR2_PACKAGE_SIGMASTAR_OSDRV_INFINITY6C
+	depends on !BR2_PACKAGE_MAJESTIC
+	help
+	  Standalone H.265 video encoder and streamer for SigmaStar
+	  Infinity6E (SSC338Q/SSC30KQ) and Infinity6C (SSC378QE). The
+	  SoC backend is selected automatically from the target SoC
+	  family. Provides a dual encoder backend, sensor unlock and an
+	  HTTP configuration API.
+
+	  It is an alternative to the Majestic streamer and cannot be
+	  built alongside it: both drive the same sensor and encoder
+	  hardware, and both rely on the SigmaStar OSDRV MI libraries,
+	  which OSDRV installs only when Majestic is not selected.
+
+	  Installs:
+	    - /usr/bin/waybeam
+	    - /etc/waybeam.json
+	    - /etc/init.d/S95waybeam

--- a/package/waybeam/files/S95waybeam
+++ b/package/waybeam/files/S95waybeam
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+DAEMON="waybeam"
+RESPAWN="waybeam-resp"
+WATCHDOG="waybeam-wd"
+DAEMON_PATH="/usr/bin/waybeam"
+LOG_PATH="/tmp/waybeam.log"
+
+# waybeam forks a respawn child (comm "waybeam-resp") on an API restart and a
+# watchdog ("waybeam-wd"). pidof and killall match by comm, so every restart
+# path must cover all three names, otherwise stop() returns while a helper is
+# still alive and the next start() trips the duplicate-instance check.
+still_running() {
+	pidof "$DAEMON" "$RESPAWN" "$WATCHDOG" >/dev/null 2>&1
+}
+
+wait_exit() {
+	i=0
+	while [ $i -lt 30 ]; do
+		still_running || return 0
+		sleep 0.5
+		i=$((i + 1))
+	done
+	echo "Warning: $DAEMON did not exit in time"
+}
+
+start() {
+	if still_running; then
+		echo "$DAEMON already running"
+		return 0
+	fi
+	echo -n "Starting $DAEMON: "
+	# waybeam reads /etc/waybeam.json from a fixed path; it has no -c flag.
+	"$DAEMON_PATH" > "$LOG_PATH" 2>&1 &
+	i=0
+	while [ $i -lt 10 ]; do
+		sleep 0.3
+		still_running && { echo "OK"; return 0; }
+		i=$((i + 1))
+	done
+	echo "FAILED (crashed at init or lost the duplicate-instance check, see $LOG_PATH)"
+	return 1
+}
+
+stop() {
+	echo -n "Stopping $DAEMON: "
+	killall "$DAEMON" "$RESPAWN" "$WATCHDOG" 2>/dev/null
+	wait_exit
+	echo "OK"
+}
+
+case "$1" in
+	start)   start ;;
+	stop)    stop ;;
+	restart) stop; start ;;
+	*)
+		echo "Usage: $0 {start|stop|restart}"
+		exit 1
+		;;
+esac

--- a/package/waybeam/files/waybeam.json
+++ b/package/waybeam/files/waybeam.json
@@ -1,0 +1,114 @@
+{
+  "system": {
+    "webPort": 80,
+    "overclockLevel": 1,
+    "verbose": false
+  },
+  "sensor": {
+    "index": -1,
+    "mode": -1
+  },
+  "isp": {
+    "sensorBin": "",
+    "aeEngine": "sdk",
+    "aeFps": 15,
+    "gainMax": 0,
+    "awbMode": "auto",
+    "awbCt": 5500,
+    "keepAspect": true
+  },
+  "image": {
+    "mirror": false,
+    "flip": false,
+    "rotate": 0
+  },
+  "video0": {
+    "rcMode": "cbr",
+    "fps": 90,
+    "size": "auto",
+    "bitrate": 2580,
+    "gopSize": 5.0,
+    "qpDelta": -12,
+    "sceneThreshold": 0,
+    "sceneHoldoff": 2,
+    "resilience": "off",
+    "zoomX": 0.5,
+    "zoomY": 0.5,
+    "framing": "off",
+    "stabCropPct": 0,
+    "stabRecenterSpeed": 0,
+    "stabKalmanQ": 0.0,
+    "stabKalmanR": 0.0
+  },
+  "outgoing": {
+    "enabled": true,
+    "server": "udp://192.168.1.10:5600",
+    "streamMode": "rtp",
+    "maxPayloadSize": 1400,
+    "connectedUdp": true,
+    "audioPort": 5601,
+    "sidecarPort": 5602
+  },
+  "discovery": {
+    "enabled": true,
+    "serviceType": "_waybeam-venc._tcp",
+    "name": "",
+    "bareAlias": true
+  },
+  "fpv": {
+    "roiEnabled": false,
+    "roiQp": 0,
+    "roiSteps": 2,
+    "roiCenter": 0.4,
+    "noiseLevel": 0
+  },
+  "audio": {
+    "enabled": false,
+    "sampleRate": 48000,
+    "channels": 1,
+    "codec": "opus",
+    "volume": 80,
+    "mute": false
+  },
+  "imu": {
+    "enabled": false,
+    "i2cDevice": "/dev/i2c-1",
+    "i2cAddr": "0x68",
+    "sampleRateHz": 200,
+    "gyroRangeDps": 1000,
+    "calFile": "/etc/imu.cal",
+    "calSamples": 400
+  },
+  "record": {
+    "enabled": false,
+    "dir": "/mnt/mmcblk0p1",
+    "format": "ts",
+    "mode": "mirror",
+    "maxSeconds": 300,
+    "maxMB": 500,
+    "bitrate": 0,
+    "fps": 0,
+    "gopSize": 0.0,
+    "server": ""
+  },
+  "snapshot": {
+    "enabled": true,
+    "quality": 80,
+    "channel": 7,
+    "width": 0,
+    "height": 0
+  },
+  "debug": {
+    "showOsd": false
+  },
+  "attitude": {
+    "enabled": false,
+    "mountDeg": 0,
+    "invertRoll": false,
+    "invertPitch": false,
+    "axisFwd": "+x",
+    "axisDown": "+z",
+    "trimRollDeg": 0.0,
+    "trimPitchDeg": 0.0
+  }
+}

--- a/package/waybeam/waybeam.mk
+++ b/package/waybeam/waybeam.mk
@@ -1,0 +1,88 @@
+################################################################################
+#
+# waybeam
+#
+################################################################################
+
+WAYBEAM_VERSION = HEAD
+WAYBEAM_SITE = https://github.com/OpenIPC/waybeam_venc.git
+WAYBEAM_SITE_METHOD = git
+WAYBEAM_LICENSE = MIT
+WAYBEAM_LICENSE_FILES = LICENSE
+
+# The encoder ships a single source tree with two SoC backends selected by
+# SOC_BUILD. Derive it from the target SoC family and build with Buildroot's
+# toolchain; CC_BIN / CC_MARUKO_BIN point the tree's toolchain check at the
+# same compiler so it does not fetch its own. The `stage` target also lays out
+# the Maruko sensor modules and ISP bins under out/maruko/; the Star6E unlocked
+# modules ship prebuilt in the source tree under sensors/star6e/.
+ifeq ($(OPENIPC_SOC_FAMILY),infinity6c)
+WAYBEAM_SOC = maruko
+WAYBEAM_MAKE_OPTS = SOC_BUILD=maruko MARUKO_CC="$(TARGET_CC)" CC_MARUKO_BIN="$(TARGET_CC)"
+# Built after the stock sensor and MI-library packages so the modified Maruko
+# sensor modules install over the stock sensor_imx*_mipi.ko names.
+WAYBEAM_DEPENDENCIES += sigmastar-osdrv-sensors sigmastar-osdrv-infinity6c
+else
+WAYBEAM_SOC = star6e
+WAYBEAM_MAKE_OPTS = SOC_BUILD=star6e STAR6E_CC="$(TARGET_CC)" CC_BIN="$(TARGET_CC)"
+# Built after the stock sensor and MI-library packages so the unlocked Star6E
+# sensor modules install over the stock sensor_imx*_mipi.ko names.
+WAYBEAM_DEPENDENCIES += sigmastar-osdrv-sensors sigmastar-osdrv-infinity6e
+endif
+
+define WAYBEAM_BUILD_CMDS
+	$(MAKE) -C $(@D) stage json_cli $(WAYBEAM_MAKE_OPTS)
+endef
+
+define WAYBEAM_INSTALL_TARGET_CMDS
+	$(INSTALL) -m 0755 -D $(@D)/out/$(WAYBEAM_SOC)/waybeam \
+		$(TARGET_DIR)/usr/bin/waybeam
+	$(INSTALL) -m 0755 -D $(@D)/out/$(WAYBEAM_SOC)/json_cli \
+		$(TARGET_DIR)/usr/bin/json_cli
+	$(INSTALL) -m 0644 -D $(WAYBEAM_PKGDIR)/files/waybeam.json \
+		$(TARGET_DIR)/etc/waybeam.json
+endef
+
+# The encoder dlopens the SigmaStar MI libraries at runtime. They are
+# installed to /usr/lib by sigmastar-osdrv-infinity6{e,c}, which does so
+# only when Majestic is not selected; waybeam depends on !MAJESTIC, so
+# that path always applies and the package ships no libraries itself.
+
+# Infinity6C (Maruko) has no in-tree modules for these sensors and Waybeam
+# uses its own modified imx335/imx415 drivers. Install them under the stock
+# _mipi.ko names, plus the matching ISP tuning bins.
+ifeq ($(WAYBEAM_SOC),maruko)
+define WAYBEAM_INSTALL_MARUKO_SENSORS
+	$(INSTALL) -m 0644 -D $(@D)/out/maruko/drivers/sensor_imx335_mipi.ko \
+		$(TARGET_DIR)/lib/modules/5.10.61/sigmastar/sensor_imx335_mipi.ko
+	$(INSTALL) -m 0644 -D $(@D)/out/maruko/drivers/sensor_imx415_mipi.ko \
+		$(TARGET_DIR)/lib/modules/5.10.61/sigmastar/sensor_imx415_mipi.ko
+	$(INSTALL) -m 0644 -D $(@D)/out/maruko/isp-bins/imx335.bin \
+		$(TARGET_DIR)/etc/sensors/imx335.bin
+	$(INSTALL) -m 0644 -D $(@D)/out/maruko/isp-bins/imx415.bin \
+		$(TARGET_DIR)/etc/sensors/imx415.bin
+endef
+WAYBEAM_POST_INSTALL_TARGET_HOOKS += WAYBEAM_INSTALL_MARUKO_SENSORS
+endif
+
+# Infinity6E (Star6E) has stock in-tree imx335/imx415 modules, but Waybeam
+# ships its own unlocked drivers (higher-FPS sensor modes, up to 144 fps
+# IMX335 / 100 fps IMX415). Install the prebuilt, --strip-debug'd .ko from the
+# source tree over the stock _mipi.ko names. Star6E needs no custom ISP bins
+# (the SDK/stock tuning applies; isp.sensorBin defaults to empty).
+ifeq ($(WAYBEAM_SOC),star6e)
+define WAYBEAM_INSTALL_STAR6E_SENSORS
+	$(INSTALL) -m 0644 -D $(@D)/sensors/star6e/sensor_imx335_star6e.ko \
+		$(TARGET_DIR)/lib/modules/4.9.84/sigmastar/sensor_imx335_mipi.ko
+	$(INSTALL) -m 0644 -D $(@D)/sensors/star6e/sensor_imx415_star6e.ko \
+		$(TARGET_DIR)/lib/modules/4.9.84/sigmastar/sensor_imx415_mipi.ko
+endef
+WAYBEAM_POST_INSTALL_TARGET_HOOKS += WAYBEAM_INSTALL_STAR6E_SENSORS
+endif
+
+define WAYBEAM_INSTALL_INIT_SYSV
+	$(INSTALL) -m 0755 -D $(WAYBEAM_PKGDIR)/files/S95waybeam \
+		$(TARGET_DIR)/etc/init.d/S95waybeam
+endef
+
+$(eval $(generic-package))


### PR DESCRIPTION
Adds a Buildroot package `waybeam`: an H.265 video encoder and streamer for
SigmaStar Infinity6E (SSC338Q/SSC30KQ) and Infinity6C (SSC378QE). The SoC
backend is selected from `OPENIPC_SOC_FAMILY`. The source is MIT-licensed and
tracks `OpenIPC/waybeam_venc` master (currently v0.40.1).

Installs:
- `/usr/bin/waybeam`
- `/usr/bin/json_cli` (config editor)
- `/etc/waybeam.json`
- `/etc/init.d/S95waybeam`

**Unlocked sensor modules (both families).** Waybeam ships its own imx335/imx415
drivers with higher-FPS sensor modes:
- **Infinity6E (Star6E):** installs the unlocked `sensor_imx{335,415}_star6e.ko`
  over the stock `/lib/modules/4.9.84/sigmastar/sensor_imx*_mipi.ko` names
  (up to 144 fps IMX335 / 100 fps IMX415). No custom ISP bins — the SDK/stock
  tuning applies (`isp.sensorBin` defaults to empty).
- **Infinity6C (Maruko):** installs `sensor_imx{335,415}_mipi.ko` plus the
  matching `/etc/sensors/imx335.bin` and `imx415.bin`, since there are no
  in-tree modules for these sensors on I6C.

Both are ordered after `sigmastar-osdrv-sensors` and the family's
`sigmastar-osdrv-infinity6{e,c}` so the modules install over the stock ones.

waybeam and Majestic cannot be built together (`depends on
!BR2_PACKAGE_MAJESTIC`): both drive the same sensor and encoder, and the
SigmaStar OSDRV MI libraries are installed to `/usr/lib` only when Majestic
is not selected. The package ships no libraries; OSDRV provides them.

Defaults in `/etc/waybeam.json`: UDP RTP output enabled to
`udp://192.168.1.10:5600`, resolution `auto` (sensor native), ROI and audio
disabled. `isp.sensorBin` is empty, which is valid — the encoder falls back
to the SDK default ISP tuning, so video comes up on first boot. The config is
kept in sync with the v0.40.1 schema (carries the `attitude` section; the dead
`frameLost` field, removed from the encoder in v0.19.0, was dropped).

Verified with scoped Buildroot builds on both families (Majestic off). Each
uses the Buildroot toolchain; the Infinity6C build installs the binary,
json_cli, both sensor modules, both ISP bins, config and init script:
- Infinity6E — glibc binary.
- Infinity6C (SSC378QE) — musl binary.

**Verification note for the Star6E sensor modules:** they ship prebuilt
(stripped `--strip-debug`) and must match the target kernel's vermagic. They
were built against the OpenIPC Infinity6E 4.9.84 kernel; a scoped I6E build +
boot check that `sensor_imx335_mipi.ko` / `imx415.ko` `insmod` cleanly and the
new modes enumerate is the remaining gate (the Maruko modules were validated
the same way).
