### PR TITLE
gk7205v200: flip dwc3 to host before unbinding xhci (otg)

### DIFF
--- a/devices/gk7205v200_otg_generic/general/overlay/usr/bin/usb-mode
+++ b/devices/gk7205v200_otg_generic/general/overlay/usr/bin/usb-mode
@@ -99,6 +99,20 @@ to_device() {
 	need_debugfs
 
 	if X=$(xhci_device) && [ -e "/sys/bus/platform/drivers/xhci-hcd/$X" ]; then
+		# Coming straight from boot the controller is still in its power-on
+		# GCTL.PRTCAPDIR = OTG(3) (see the header note: nothing moves it off
+		# OTG on its own). xhci-hcd binds and registers both buses on top of
+		# that anyway, but it is not actually driving the port -- so unbinding
+		# directly from OTG asks xhci_halt() to halt a host that was never
+		# really running, and it times out:
+		#   xhci-hcd.0.auto: Host not halted after 16000 microseconds.
+		#   xhci-hcd.0.auto: Host controller not halted, aborting reset.
+		# Leaving the controller un-halted is precisely the live-DMA-engine
+		# state this unbind exists to avoid. Flip to host first so the already
+		# bound xHCI is genuinely running, and the unbind then halts cleanly.
+		# A switch from host is already in that state, so only boot pays for it.
+		[ "$(cat "$MODE_FILE")" = host ] || echo host > "$MODE_FILE"
+
 		echo "usb-mode: unbinding host controller $X"
 		echo "$X" > /sys/bus/platform/drivers/xhci-hcd/unbind
 	fi


### PR DESCRIPTION
Booting the `otg` profile with `/etc/usbmode` = `device` made `S72usbmode`'s `usb-mode device` log, on **every** boot:

```
xhci-hcd xhci-hcd.0.auto: Host not halted after 16000 microseconds.
xhci-hcd xhci-hcd.0.auto: Host controller not halted, aborting reset.
```

## Cause

`dwc3_core_init()` leaves `GCTL.PRTCAPDIR = OTG(3)`, and this 4.9 dwc3 never moves off OTG on its own — the same fact `S72usbmode`'s header already documents. `xhci-hcd` binds and registers both buses on top of that anyway, but it is not actually driving the port. Unbinding straight from OTG therefore asks `xhci_halt()` to halt a host that was never really running, and it times out.

The gadget composed regardless, so this was cosmetic in practice — but it left the host controller un-halted, which is precisely the live-DMA-engine state the unbind exists to avoid.

This is *not* a probe/timing race. Confirmed by whiting out `S72usbmode` and rebooting so nothing touched the controller:

```
dwc3 PRTCAPDIR : OTG     <- never leaves its power-on state
xhci bound     : yes     <- binds on top of it regardless
halt warnings  : 0       <- no unbind attempted, so no warning
```

Then `echo host > mode` followed by a manual unbind → still 0 warnings. That isolates the trigger to unbind-while-OTG.

## Fix

Flip the controller to host before unbinding, so the already-bound xHCI is genuinely running and the unbind halts cleanly. A runtime switch from host is already in that state, so only boot pays for the extra flip.

## Testing

On a gk7205v200 (Xiongmai `IPC_GK7205V200_50H20AI_S38`) running `gk7205v200_otg_generic`:

| | before | after |
|---|---|---|
| cold boots warning | 5/5 | **0/5** |
| runtime round trips warning | 0 | 0 |

All 5 boots come up `role=device`, gadget bound to `10030000.dwc3`, `/dev/video0` present. Two runtime `host`↔`device` round trips stay clean, still ~0.35s, with no reboot and no majestic restart.

## Note for reviewers

An earlier attempt treated this as a probe race and polled for xHCI to settle before unbinding. It changed nothing — the wait succeeded and the halt still failed — which is what refuted the race hypothesis. That approach is deliberately not in this PR.

Relatedly, do not gate such a wait on "every root hub has its hub interface driver bound": on this SoC the USB3 root hub never gets a driver (`hub 2-0:1.0: hub can't support USB3.0`), so that condition can never be satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
