### PR TITLE
ci: keep inherited workflows from billing non-canonical repos

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,6 +15,9 @@ concurrency:
 jobs:
   prune:
     name: Prune old nightly releases
+    # Canonical repo only on the weekly cron -- see master.yml's preflight.
+    # Dispatch runs are unaffected.
+    if: github.event_name != 'schedule' || github.repository == 'OpenIPC/builder'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -19,9 +19,16 @@ jobs:
     # transient toolchain 502) should not deny manifest updates for the
     # platforms that did upload artifacts. enrich_manifest.py reads
     # whatever assets actually exist on the release.
+    #
+    # First clause: on a mirror the nightly's jobs skip, but the run still
+    # completes and fires workflow_run, so gate the cron-originated path on
+    # the canonical repo too -- see master.yml's preflight. Dispatch-driven
+    # manifest regeneration is untouched anywhere.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)
+      (github.event.workflow_run.event != 'schedule' ||
+       github.repository == 'OpenIPC/builder') &&
+      (github.event_name == 'workflow_dispatch' ||
+       contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master (for the script)

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,6 +11,22 @@ on:
 jobs:
   preflight:
     name: Preflight
+    # Guard rail for clones of this repo. A clone pushed to a new repository
+    # (a private mirror, an internal re-host) inherits this file along with
+    # its cron, and the full platform matrix then runs on that owner's Actions
+    # bill, nightly and unattended, publishing nightlies nobody reads. Forks
+    # are partially covered (GitHub disables scheduled workflows there), a
+    # fresh repository is not. Mirrors OpenIPC/firmware#2255.
+    #
+    # Unattended runs happen only on the canonical repo. Anywhere else a
+    # workflow runs only if someone explicitly asked for it, or if it is both
+    # free and attended. The pull_request clause is unreachable today -- this
+    # workflow has no pull_request trigger -- and is kept deliberately, so
+    # that adding one later does not silently skip CI on contributor forks.
+    if: >-
+      github.repository == 'OpenIPC/builder' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private)
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.gate.outputs.should_build }}


### PR DESCRIPTION
Mirrors OpenIPC/firmware#2255 into this repo. Same problem, same rule, adjusted for this repo's trigger set.

### Problem

Push a clone of this repo to a new repository (private mirror / internal re-host) and `.github/workflows` comes along with its cron. The full platform matrix then runs **on that owner's Actions bill** — nightly, unattended, publishing nightlies nobody reads. Forks are only partially protected: GitHub disables *scheduled* workflows on forks, but a fresh repository gets no protection and no warning.

Measured upstream on one private mirror of `firmware`, from a single night: **97 jobs, 2,146 billed minutes**. And it never converges — the mirror's publish step fails (no `nightly` release exists there), so `preflight`'s sha skip-gate never engages and the full matrix rebuilds **every** night. This repo carries the same preflight/cleanup/manifest design and its own daily cron, so a clone of it reproduces that exactly.

### The rule

**Unattended runs happen only on the canonical repo.** Anywhere else a workflow runs only if someone explicitly asked for it (`workflow_dispatch`), or if it is both free and attended (`pull_request` on a public repo).

```yaml
if: >-
  github.repository == 'OpenIPC/builder' ||
  github.event_name == 'workflow_dispatch' ||
  (github.event_name == 'pull_request' && !github.event.repository.private)
```

Deliberately stricter than "gate it where the minutes stop being free": a public re-host's minutes *are* free and its cron is still skipped, because a re-host quietly publishing `nightly` releases under its own name is a worse outcome than wasted minutes.

| event | where | result |
|---|---|---|
| `schedule` | OpenIPC/builder | runs (unchanged) |
| `workflow_dispatch` | anywhere | runs (an operator explicitly asked; `build-one.yml` untouched) |
| `schedule` | public re-host | **skips** (deliberate — see above) |
| `schedule` | private mirror | **skips** |

### Coverage

`master.yml` carries the guard on `preflight`; `buildroot` needs it and inherits the skip. `manifest.yml` gates its cron-originated `workflow_run` path the same way — a nightly whose jobs all skipped still completes and fires `workflow_run`. `cleanup.yml` carries it on its weekly cron. `build-one.yml` is dispatch-only and needs nothing.

### Two deliberate differences from the firmware PR

**The `pull_request` clause is unreachable here** — no workflow in this repo has a `pull_request` trigger. It is kept on purpose. It is the clause that *lets contributor PRs run*, and dropping it would mean that adding a `pull_request` trigger later silently skips CI on every fork. That exact over-block was the first thing reviewers caught on the upstream attempt (OpenIPC/firmware#2254), and it is cheaper to carry a correct-if-reached disjunct than to re-derive it under time pressure.

**No `ci-gate` equivalent to guard.** Upstream, `ci-gate` is `if: always()`, so skipping `preflight` did *not* skip the gate — it ran anyway, read `preflight=skipped` and exited 1, turning a saved build into a red run. This repo has no such job, so there is nothing to guard. Worth knowing if one is ever added: an `always()` job needs the guard too, as `always() && (...)`.

### Upstream impact

None. On `OpenIPC/builder` the first disjunct is true, so every added condition is a tautology and each job's `if` reduces to what it was before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
