### PR TITLE
ci: publish the devices that did build when the matrix goes red

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -327,7 +327,24 @@ jobs:
   publish:
     name: Publish releases
     needs: [preflight, select, buildroot]
+    # The leading status function is load-bearing. A job whose `needs` failed is
+    # skipped by default, and an `if:` lifts that only when it CONTAINS a status
+    # function -- reading `needs.buildroot.result` inside the `contains()` below
+    # does not count. So since #121 gave this job the matrix as a dependency,
+    # any single failing device skipped it outright and the whole release went
+    # unwritten: 2026-08-24 lost every device's nightly to one failure out of 98
+    # (ssc333_lite_meari-speed-6s), and 2026-08-21 lost it to two out of 98.
+    # There is no nightly-20260821-* or nightly-20260824-* release as a result.
+    # Before #121 each device uploaded from its own matrix job, so a bad device
+    # took down only itself; this restores that without giving up the
+    # single-writer fix that stopped the concurrent-upload rate limits.
+    #
+    # `!cancelled()` rather than `always()`: the `contains()` already drops a
+    # cancelled or skipped matrix, but a run cancelled AFTER a green matrix
+    # would still start uploading under `always()`, and a half-written nightly
+    # is the thing this job exists to avoid.
     if: >-
+      !cancelled() &&
       github.event_name != 'pull_request' &&
       needs.preflight.outputs.should_build == 'true' &&
       contains(fromJSON('["success", "failure"]'), needs.buildroot.result)
@@ -376,6 +393,13 @@ jobs:
             fi
           elif [ "${count}" -eq 0 ]; then
             echo "::notice::matrix failed and produced nothing; no release to write"
+          else
+            # The partial case this job was always meant to serve, unreachable
+            # until the `!cancelled()` above. Say so out loud: the devices that
+            # did not build keep their PREVIOUS image on nightly/latest, which
+            # is the right outcome for a flasher but is invisible next to the
+            # freshly-written ones.
+            echo "::warning::partial publish: matrix failed, writing the ${count} asset(s) that did build; nightly and latest keep their previous image for every device that did not"
           fi
 
       # Drive the release writes with gh rather than softprops/action-gh-release,

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -399,7 +399,7 @@ jobs:
             # did not build keep their PREVIOUS image on nightly/latest, which
             # is the right outcome for a flasher but is invisible next to the
             # freshly-written ones.
-            echo "::warning::partial publish: matrix failed, writing the ${count} asset(s) that did build; nightly and latest keep their previous image for every device that did not"
+            echo "::warning::partial publish: matrix failed, writing the ${count} asset(s) that did build; nightly and latest keep their previous image for every device that did not build — see the failed jobs in this run for which"
           fi
 
       # Drive the release writes with gh rather than softprops/action-gh-release,


### PR DESCRIPTION
## Symptom

This morning's nightly ([32687796386](https://github.com/OpenIPC/builder/actions/runs/32687796386))
built 97 of 98 devices. `ssc333_lite_meari-speed-6s` failed, and that one device cost **every**
device its release:

- no `nightly-20260824-*` release exists
- `nightly` and `latest` still carry the 23rd's images

2026-08-21 ([32444493109](https://github.com/OpenIPC/builder/actions/runs/32444493109)) went the
same way on two failures out of 98 — no `nightly-20260821-*` either. Those are the only two
nightlies to have failed since #121, and both lost their entire release.

## Cause

`publish` is documented as best-effort — *"publish whatever the matrix produced even if some
devices failed"* — and its condition already lists `'failure'` as an accepted matrix result:

```yaml
needs: [preflight, select, buildroot]
if: >-
  github.event_name != 'pull_request' &&
  needs.preflight.outputs.should_build == 'true' &&
  contains(fromJSON('["success", "failure"]'), needs.buildroot.result)
```

It never got that far. A job whose `needs` failed is skipped by default, and an `if:` overrides
that **only when it contains a status function**. Reading `needs.buildroot.result` inside
`contains()` does not count. The job was skipped outright, never evaluated, and reported
`skipped` rather than anything red — which is why nothing pointed at it.

This dates from #121, which consolidated the release writes into a single writer to stop the
concurrent-upload rate limits. That change was right; before it each device uploaded from its own
matrix job, so a failing device took down only itself.

## Fix

`!cancelled() &&` on the publish gate, which lifts the implicit `success()`.

`!cancelled()` rather than `always()` on purpose: the `contains()` already drops a cancelled or
skipped matrix, but a run cancelled *after* a green matrix would still start uploading under
`always()`, and a half-written nightly is what the single-writer design exists to avoid.

Also adds a `::warning::partial publish: …` line to `Collect assets`, naming how many assets are
being written and stating that devices which did not build keep their previous image on
`nightly`/`latest` — true and correct for a flasher, but invisible next to freshly-written ones.

## What is deliberately unchanged

The gate still fails the run when any device fails. Both properties are meant to hold at once,
and now do: **the run reports red and still delivers the images it built.**

## Verification

- `master.yml` parses under PyYAML and the condition survives as a string. The `>-` block scalar
  is load-bearing: a leading `!` in a single-line `if:` would be read as a YAML tag.
- `python3 .github/scripts/lint-workflow-shell.py` — 23/23 run blocks parse clean, self-test passes
- `python3 .github/scripts/ci-matrix.py --self-test` — ok (107 devices, 15 smoke, 33 cases)
- Condition audited across every path. PR, no-op schedule, clone guard, cancelled run, failed
  `select` and all-devices-failed all still skip. Only "matrix failed, some devices built" changes
  from skip to publish; on that path `Collect assets` finds a non-zero count and the existing
  publish step runs — the code path this job was written for and has never reached.

Note this path is unreachable from PR CI by construction (`github.event_name != 'pull_request'`),
the same blind spot that let #121's missing `fi` through and prompted the shell linter in #122.
So a green check here does not exercise the change; the first partially-failed nightly is what
proves it.

## Test plan

- [x] `lint-workflow-shell.py` clean, self-test passes
- [x] `ci-matrix.py --self-test` clean
- [x] YAML parses, `if:` string intact
- [ ] first partially-failed nightly writes a dated release plus fresh `nightly`/`latest` for the
      devices that built, and the gate is still red

## Related

Same fix as OpenIPC/firmware#2303 — the two publish jobs share a common ancestor and carried the
identical gate. firmware lost its 2026-08-23 nightly (all 113 assets) to one board 4KB over a
size cap.
