### PR TITLE
ci: stop a NOT_BUILT device widening the matrix to all of them

### DIFF
--- a/.github/scripts/ci-matrix.py
+++ b/.github/scripts/ci-matrix.py
@@ -171,6 +171,15 @@ class Tree:
         """Every built target whose defconfig lives in devices/<dir>/."""
         return [t for t in self.built if self.directory_of[t] == directory]
 
+    def devices_in(self, directory):
+        """Every target in devices/<dir>/, whether CI builds it or not.
+
+        targets_in() answers "what would this build", which is what narrowing
+        needs. This answers "is this a directory we know", which is what telling
+        a deliberate opt-out apart from an unrecognised path needs.
+        """
+        return [t for t in self.directory_of if self.directory_of[t] == directory]
+
 
 def classify(tree, changed, labels=(), event="pull_request", draft=False):
     """Map a list of changed paths to {rows, needs_build, reason}."""
@@ -219,6 +228,14 @@ def classify(tree, changed, labels=(), event="pull_request", draft=False):
             hits = tree.targets_in(f"devices/{device.group(1)}")
             if hits:
                 targets.update(hits)
+                continue
+            if tree.devices_in(f"devices/{device.group(1)}"):
+                # The directory is known -- every device in it is in NOT_BUILT.
+                # Reaching nothing is the whole point of that list, and their
+                # defconfigs already behave this way, so an overlay or kernel
+                # config beside one has to as well. Without this the opt-out
+                # inverts: touching a device CI deliberately skips widens to
+                # all of them.
                 continue
             return _decision(full, True,
                              reason=f"{path} is in no directory CI builds")
@@ -382,6 +399,17 @@ def self_test():
         # A defconfig CI does not build contributes nothing.
         (["devices/t31_lite_tp-link-tapo-tc70-v3/br-ext-chip-ingenic/configs/"
           "t31_lite_tp-link-tapo-tc70-v3_defconfig"], 0, "an unbuilt device"),
+        # ...and so does anything else in that device's directory. Its kernel
+        # config is the case that regressed: OpenIPC/builder#126 touched three
+        # NOT_BUILT devices and got the full 107 for it.
+        (["devices/gk7205v200_rubyfpv_generic/br-ext-chip-goke/board/gk7205v200/"
+          "gk7205v200.generic-fpv.config"], 0, "a kernel config in an unbuilt device"),
+        (["devices/t31_lite_tp-link-tapo-tc70-v3/general/overlay/etc/inittab"],
+         0, "an overlay file in an unbuilt device"),
+        # A directory with no defconfig at all is still unknown, and unknown
+        # still widens -- that is the half of this rule worth keeping.
+        (["devices/a-device-that-does-not-exist/br-ext-chip-goke/board/x.config"],
+         full, "a devices/ directory with no defconfig widens"),
         # Everything shared or unknown widens.
         (["builder.sh"], full, "the build script"),
         (["package/kc110-board-support/Config.in"],


### PR DESCRIPTION
Split out of #126, which tripped over this.

## The bug

`NOT_BUILT` is documented as the opt-out that narrows to nothing:

> Devices that exist in the tree but are deliberately not built: the opt-out from the rule above. […] Changes to these narrow to nothing, exactly as they do today.

A change to one of those devices' **defconfigs** does exactly that. Anything **else** in the same directory did the opposite:

```console
$ echo devices/gk7205v200_rubyfpv_generic/br-ext-chip-goke/board/gk7205v200/gk7205v200.generic-fpv.config \
    | python3 .github/scripts/ci-matrix.py --stdin
ci-matrix: 107/107 devices (needs_build=True) --- … is in no directory CI builds

$ echo devices/gk7205v200_rubyfpv_generic/br-ext-chip-goke/configs/gk7205v200_rubyfpv_generic_defconfig \
    | python3 .github/scripts/ci-matrix.py --stdin
ci-matrix: 0/107 devices (needs_build=False) --- nothing that reaches a build
```

Same device, same opt-out, opposite answers. Touching a device CI deliberately skips cost a full 107-device run — #126 touches three `NOT_BUILT` devices and is building all 107 because of it.

## Why

`targets_in()` only ever returns devices CI builds, so a directory holding nothing but opted-out devices comes back empty and falls through to the `is in no directory CI builds` widen. The empty result was carrying two meanings:

1. every device here is opted out → should reach nothing
2. this directory is not one I know → should widen

Only the second should widen. `devices_in()` answers the second question directly — it reads `directory_of`, which is built from every defconfig in the tree rather than the built subset — so an unrecognised directory still widens. That is the half of the rule worth keeping, and it stays.

## Self-test

Three cases, one per meaning:

| path | expected |
|---|---|
| kernel config in a `NOT_BUILT` device | 0 |
| overlay file in a `NOT_BUILT` device | 0 |
| `devices/<no such device>/…` (no defconfig anywhere in it) | full 107 |

```console
$ python3 .github/scripts/ci-matrix.py --self-test
ci-matrix: self-test ok (107 devices, 15 smoke, 36 cases)
```

(33 cases before.)

## Effect on #126

```console
$ git show --name-only --format= <#126 head> | python3 .github/scripts/ci-matrix.py --stdin
ci-matrix: 23/107 devices (needs_build=True) --- narrowed to the affected devices
```

18 from `devices/common` — the directory is the copy unit, so all 18 targets sharing it are in scope — plus the 5 individually-named devices CI builds. The four `NOT_BUILT` devices #126 touches now contribute nothing, as their defconfigs already did.

## Note on cost

This PR necessarily builds all 107: `.github/scripts/ci-matrix.py` is deliberately absent from `SMOKE_WORKFLOWS` because it cannot be trusted to decide a smaller matrix for itself. That is working as intended and I have not touched it.
