### PR TITLE
ci: build the KC110 and the Tapo TC70 v3 instead of skipping them

### DIFF
--- a/.github/scripts/ci-matrix.py
+++ b/.github/scripts/ci-matrix.py
@@ -70,7 +70,6 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 NOT_BUILT = {
     "gk7102ca_lite_umea-qc01x", "gk7102ca_lite_vstarcam-g8896wip",
     "gk7205v200_rubyfpv_generic", "hi3518ev200_lite_lenovo-snowman-1080p",
-    "hi3518ev200_ultimate_tplink-kasa-kc110", "t31_lite_tp-link-tapo-tc70-v3",
     "t31_lite_xiaomi-mjsxj05hl",
 }
 
@@ -403,15 +402,15 @@ def self_test():
         (["devices/common/br-ext-chip-goke/configs/gk7205v200_fpv_defconfig"],
          1, "a defconfig in a shared directory is still one device"),
         # A defconfig CI does not build contributes nothing.
-        (["devices/t31_lite_tp-link-tapo-tc70-v3/br-ext-chip-ingenic/configs/"
-          "t31_lite_tp-link-tapo-tc70-v3_defconfig"], 0, "an unbuilt device"),
+        (["devices/t31_lite_xiaomi-mjsxj05hl/br-ext-chip-ingenic/configs/"
+          "t31_lite_xiaomi-mjsxj05hl_defconfig"], 0, "an unbuilt device"),
         # ...and so does anything else in that device's directory. Its kernel
         # config is the case that regressed: OpenIPC/builder#126 touched three
         # NOT_BUILT devices and got the full 107 for it.
         (["devices/gk7205v200_rubyfpv_generic/br-ext-chip-goke/board/gk7205v200/"
           "gk7205v200.generic-fpv.config"], 0, "a kernel config in an unbuilt device"),
-        (["devices/t31_lite_tp-link-tapo-tc70-v3/general/overlay/etc/inittab"],
-         0, "an overlay file in an unbuilt device"),
+        (["devices/t31_lite_xiaomi-mjsxj05hl/general/overlay/usr/share/"
+          "openipc/customizer.sh"], 0, "an overlay file in an unbuilt device"),
         # A directory with no defconfig at all is still unknown, and unknown
         # still widens -- that is the half of this rule worth keeping.
         (["devices/a-device-that-does-not-exist/br-ext-chip-goke/board/x.config"],


### PR DESCRIPTION
Both devices have had a complete `devices/<dir>/` in this tree for a long time and have never once been built. #120 froze that state rather than changing it — it put the 7 defconfigs that were in no `master.yml` matrix into `NOT_BUILT` so that a device falling out of CI would be a test failure instead of a silent skip. Freezing was right for a change whose job was to *not* alter what gets built; it was never meant to be permanent for devices whose only problem is that nobody added the matrix line.

Two contributors did try to add that line. #111 (Tapo TC70 v3, July) and #108 (KC110, June) both append to the device list in `master.yml`, which is where the registry lived when they were written. It does not live there any more — the matrix is read off the tree — so both PRs are merge conflicts now, and the devices they asked for are exactly the two entries removed here.

This is their CI half, landed the way the selector wants it. #108 also carries a `BR2_OPENIPC_MAJESTIC="ultimate"` line and a vendor `libsns_ov2735.so` for the no-video bug; those are unaffected by any of this and stay with that PR.

### Self-test

The two cases that used `t31_lite_tp-link-tapo-tc70-v3` as their example of an unbuilt device move to `t31_lite_xiaomi-mjsxj05hl`, which is still in `NOT_BUILT`. The overlay case also switches to a path that exists, since the device it now names has no `etc/inittab`.

```
$ python3 .github/scripts/ci-matrix.py --self-test
ci-matrix: self-test ok (109 devices, 15 smoke, 39 cases)
```

Before, both devices reached nothing; now each narrows to itself:

```
$ echo devices/hi3518ev200_ultimate_tplink-kasa-kc110/general/overlay/usr/bin/load_hisilicon \
    | python3 .github/scripts/ci-matrix.py --stdin
ci-matrix: 1/109 devices (needs_build=True) --- narrowed to the affected devices
  hi3518ev200_ultimate_tplink-kasa-kc110
```

### Note on cost

Neither device has ever been through a build, so this PR is where we find out. That is affordable exactly once: a change to `ci-matrix.py` cannot narrow — it is what does the narrowing — so this runs the full 109-device matrix and proves both of them in the same run.
