### PR TITLE
ci: let a pull request keep the image it just built

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -274,10 +274,14 @@ jobs:
       # schemes the build used (compound devices rename to <device>-nor.tgz in
       # the workspace root, simple ones leave openipc.<soc>-nor-<variant>.tgz
       # under openipc/output/images/).
+      # Runs on pull_request too. Staging and the upload below are run-scoped
+      # and touch no secret and no shared state, so unlike `Send binary` and the
+      # `publish` job -- which stay gated, and must -- there is nothing here for
+      # a PR to leak or clobber. Without this a contributor's PR compiles a full
+      # image and then discards it, so they cannot test their own device profile
+      # without asking a maintainer to dispatch build-one for them.
       - name: Stage artifacts
-        if: >-
-          github.event_name != 'pull_request' &&
-          (env.NORFW || env.NANDFW)
+        if: env.NORFW || env.NANDFW
         run: |
           mkdir -p dist
           for f in "${NORFW:-}" "${NANDFW:-}" "${SIZES:-}"; do
@@ -297,15 +301,20 @@ jobs:
       # contention (run 27108181857: every board built, 14 jobs red in their
       # upload step). Consolidating every release write into one job removes the
       # concurrent-writer contention that causes it.
+      #
+      # `publish` carries its own `github.event_name != 'pull_request'`, so
+      # producing fw-* on a PR cannot reach a release; it only makes the image
+      # downloadable from the run that built it. 7 days rather than 1 because a
+      # nightly's artifact is consumed by `publish` in the same run and never
+      # needs to outlive it, while a contributor in another timezone plausibly
+      # cannot act on a one-day window.
       - name: Upload build artifacts
-        if: >-
-          github.event_name != 'pull_request' &&
-          (env.NORFW || env.NANDFW)
+        if: env.NORFW || env.NANDFW
         uses: actions/upload-artifact@v4
         with:
           name: fw-${{ matrix.platform }}
           if-no-files-found: ignore
-          retention-days: 1
+          retention-days: 7
           path: dist/*
 
       - name: Send binary

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -304,17 +304,21 @@ jobs:
       #
       # `publish` carries its own `github.event_name != 'pull_request'`, so
       # producing fw-* on a PR cannot reach a release; it only makes the image
-      # downloadable from the run that built it. 7 days rather than 1 because a
-      # nightly's artifact is consumed by `publish` in the same run and never
-      # needs to outlive it, while a contributor in another timezone plausibly
-      # cannot act on a one-day window.
+      # downloadable from the run that built it.
+      #
+      # Retention is per-event deliberately. A nightly's artifact is consumed by
+      # `publish` inside the same run and no one downloads it afterwards, and a
+      # nightly builds the entire device matrix -- holding those a week would
+      # keep seven full matrices in storage instead of one, for no reader. A PR
+      # builds a handful and has a person waiting on them, plausibly in another
+      # timezone, so one day is too short a window there.
       - name: Upload build artifacts
         if: env.NORFW || env.NANDFW
         uses: actions/upload-artifact@v4
         with:
           name: fw-${{ matrix.platform }}
           if-no-files-found: ignore
-          retention-days: 7
+          retention-days: ${{ github.event_name == 'pull_request' && 7 || 1 }}
           path: dist/*
 
       - name: Send binary


### PR DESCRIPTION
`Stage artifacts` and `Upload build artifacts` were gated on
`github.event_name != 'pull_request'`, sharing that guard with `Send binary` and
the `publish` job. Those two need it — one uses the Telegram bot secret, the
other writes shared release assets. The upload does not:
`actions/upload-artifact` is run-scoped and touches no secret and no shared
mutable state.

The effect is that a pull request compiles a complete firmware image and then
discards it. `Stage artifacts`, `Upload build artifacts`, `Send binary` and
`Publish releases` all report **skipped** on a green PR run, and the artifact
count is zero. A contributor adding a device profile therefore cannot obtain the
image their own PR just built — the only route to a flashable file is asking a
maintainer to dispatch `build-one` for them.

#119 hit exactly this. The author planned to "flash the CI artifact once this
branch produces one", which would never have resolved; I dispatched `build-one`
by hand to unblock it.

## Why this is safe

`publish` carries its own `github.event_name != 'pull_request'` in its `if:`,
independently of these steps:

```yaml
if: >-
  !cancelled() &&
  github.event_name != 'pull_request' &&
  needs.preflight.outputs.should_build == 'true' &&
  contains(fromJSON('["success", "failure"]'), needs.buildroot.result)
```

So producing `fw-*` on a pull request cannot reach a release. It only makes the
image downloadable from the run that built it. `Send binary` keeps its guard
too, so no PR touches the Telegram secret or the dev channel.

## What it costs

`select` narrows the matrix via `ci-matrix.py`, and the cost depends on what the
PR touches — measured, not estimated:

| PR shape | devices built | of 96 |
| --- | --- | --- |
| device profile (#119) | **1** | 1% |
| CI infrastructure (this PR) | **15** | 16% |

So the case this change exists for — a contributor adding a device — produces a
single ~7 MB artifact. A workflow change like this one produces 15, roughly
100 MB at 7-day retention. Both are modest, but the second is not "one image per
PR" and I would rather state it than round it down.

## Retention, per event

```yaml
retention-days: ${{ github.event_name == 'pull_request' && 7 || 1 }}
```

A nightly's artifact is consumed by `publish` inside the same run and nobody
downloads it afterwards, so a nightly gains nothing from a longer window — and
since it builds the whole matrix daily, a week of retention would keep seven
full matrices in storage instead of one, for no reader. A PR builds a handful
and has a person waiting on them, so one day is too short there.

The first revision of this PR set `7` unconditionally, which contradicted that
reasoning; corrected in b14cc52 after review.

## Verification

The change is two `if:` simplifications and one retention bump; the guards that
matter are untouched. `.github/scripts/lint-workflow-shell.py` passes — 31 run
blocks, all clean.

The honest test is this PR's own run: **`Upload build artifacts` should now
succeed and attach `fw-*`, while `Publish releases` stays skipped.** If both hold
here, the change does what it claims. Worth confirming that before merge rather
than taking the reasoning for it.
