### PR TITLE
builder.sh: propagate the build failure instead of always exiting 0

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -154,7 +154,27 @@ echo_c 33 "\nCopying device files"
 cp -afv ${BUILDER_DIR}/${ITEM}/* ${FIRMWARE_DIR}
 
 echo_c 33 "\nBuilding the device"
+# Propagate make's status. Without this the script ALWAYS exits 0: the result is
+# discarded, copy_to_archive then runs over an empty output/images and still
+# prints "Assembled firmware available in:", and the caller sees success over an
+# empty directory.
+#
+# The expensive consequence is in CI. master.yml calls this inside a retry loop
+# written as `bash builder.sh ${NAME} && break`, wrapped in a six-step backoff
+# meant to absorb transient toolchain and CDN flakes. A script that cannot fail
+# breaks on the first attempt, so the budget never retried anything and the
+# `exit 1` after the loop was unreachable — a genuinely failed build reported
+# green instead of being re-attempted.
+#
+# Explicit rather than `set -e` at the top: this script does a lot of unguarded
+# cp/rm/cd, and enabling errexit globally would change failure behaviour well
+# beyond this line.
 make BOARD=${DEVICE}
+BUILD_RC=$?
+if [ ${BUILD_RC} -ne 0 ]; then
+    echo_c 31 "\nBuild FAILED (make exited ${BUILD_RC}) - not archiving"
+    exit ${BUILD_RC}
+fi
 
 # Best-effort: emit per-package/per-kernel-module size JSON next to the .tgz.
 # Target lives in firmware's Makefile (PR #2166); ignore failure so legacy


### PR DESCRIPTION
`make BOARD=${DEVICE}` is unguarded and nothing checks its status, so `builder.sh`
always exits 0. `copy_to_archive` then runs regardless and prints
`Assembled firmware available in:` over an empty directory.

The misleading banner is the small part. The expensive part is what it does to CI,
which @widgetii pointed out on #119 — `master.yml` calls this inside a retry loop:

```yaml
for sleep_for in $backoffs ""; do
  bash builder.sh ${NAME} && break
  ...
  echo "::error::build failed after ${attempt} attempts"
  exit 1
done
```

A script that cannot fail satisfies `&& break` on the first attempt. So the
six-step backoff budget, added specifically to absorb transient toolchain and CDN
flakes, has never retried anything, and the `exit 1` after the loop is
unreachable. A genuinely failed build reports green rather than being
re-attempted.

Until #135 this was masked downstream: `Stage artifacts` is gated on `env.NORFW`,
so a failed build merely skipped the upload rather than failing the job. Now that
a PR keeps the image it built, a green job with no `fw-*` attached is a reliable
tell that the build failed silently — which makes propagating the status more
useful, not less.

### How I hit it

Building `gk7202v300_lite_generic-w7` locally, `make` died partway through
(unrelated host problem — an emulated x86_64 toolchain segfaulting gcc). The
script still printed the archive banner and returned 0, and I briefly believed I
had an image. The directory was empty.

### The change

```sh
make BOARD=${DEVICE}
BUILD_RC=$?
if [ ${BUILD_RC} -ne 0 ]; then
    echo_c 31 "\nBuild FAILED (make exited ${BUILD_RC}) - not archiving"
    exit ${BUILD_RC}
fi
```

Deliberately **not** `set -e` at the top, per @widgetii's suggestion and for the
same reason: this script does a lot of unguarded `cp`/`rm`/`cd`, and enabling
errexit globally would change failure behaviour well beyond this line. The
explicit form touches exactly the status that callers depend on.

`size-report` keeps its `|| true` — it is genuinely best-effort against older
pinned firmware refs.

`sh -n` clean. Verified the new path returns the make status rather than 0.

Branched from `222db9e` rather than current master only because my token cannot
create the newer workflow files on my fork; `builder.sh` is byte-identical at both
commits, so the diff is exactly the twenty lines above.

Refs: OpenIPC/builder#119
