### PR TITLE
customizer: gpio_motors becomes ptz_gpio, with ptz_control naming the method

### DIFF
--- a/devices/ssc30kd_lite_cmcc-ds-ytj5301/general/overlay/usr/share/openipc/customizer.sh
+++ b/devices/ssc30kd_lite_cmcc-ds-ytj5301/general/overlay/usr/share/openipc/customizer.sh
@@ -37,7 +37,8 @@ cli -s .audio.speakerPin 11
 # Set motor and mmc
 #
 #fw_setenv gpio_mmc XX
-fw_setenv gpio_motors 111 112 113 114 59 60 8 9
+fw_setenv ptz_control gpio
+fw_setenv ptz_gpio 111 112 113 114 59 60 8 9
 #
 #
 #adduser viewer -s /bin/false -D -H ; echo viewer:123456 | chpasswd

--- a/devices/t23_lite_jooan-a6m-u/general/overlay/usr/share/openipc/customizer.sh
+++ b/devices/t23_lite_jooan-a6m-u/general/overlay/usr/share/openipc/customizer.sh
@@ -44,7 +44,8 @@ fw_setenv rmem 19M@0x2D00000
 # Set motor and mmc
 #
 fw_setenv gpio_mmc 61
-#fw_setenv gpio_motors 53 52 54 14 17
+#fw_setenv ptz_control gpio
+#fw_setenv ptz_gpio 53 52 54 14 17
 #
 #
 #adduser viewer -s /bin/false -D -H ; echo viewer:123456 | chpasswd

--- a/devices/t23_lite_jooan-q3r-u/general/overlay/usr/share/openipc/customizer.sh
+++ b/devices/t23_lite_jooan-q3r-u/general/overlay/usr/share/openipc/customizer.sh
@@ -43,7 +43,8 @@ fw_setenv rmem 19M@0x2D00000
 # Set motor and mmc
 #
 fw_setenv gpio_mmc 61
-fw_setenv gpio_motors 53 52 54 14 17
+fw_setenv ptz_control gpio
+fw_setenv ptz_gpio 53 52 54 14 17
 #
 #
 #adduser viewer -s /bin/false -D -H ; echo viewer:123456 | chpasswd


### PR DESCRIPTION
Completes the #227 PTZ env rename ([majestic-webui#232](https://github.com/OpenIPC/majestic-webui/pull/232), [firmware#2341](https://github.com/OpenIPC/firmware/pull/2341)) in the last place still writing the old name, as requested by @flyrouter in [majestic-webui#227](https://github.com/OpenIPC/majestic-webui/issues/227): the three `customizer.sh` files carrying `fw_setenv gpio_motors …` now write `ptz_gpio` instead. The `gpio-motors` utility reads `ptz_gpio` first and falls back to `gpio_motors` since firmware#2341, and it is the only consumer of the variable anywhere in the org, so the rename is mechanical.

Each device also gains `fw_setenv ptz_control gpio` — not part of the rename, but required by it: the WebUI is dropping its auto-detection from a bare pin list (unset `ptz_control` now means no PTZ, per flyrouter's ruling on the same issue; [majestic-webui#255](https://github.com/OpenIPC/majestic-webui/pull/255)). Without the method named, these devices would keep their motors but lose their pads.

- `devices/t23_lite_jooan-q3r-u` — active, 5 pins
- `devices/ssc30kd_lite_cmcc-ds-ytj5301` — active, 8 pins
- `devices/t23_lite_jooan-a6m-u` — the pin line was commented out, so both new lines are commented there too