### PR TITLE
xm-85h50ai: turn on majestic's autofocus out of the box

### DIFF
--- a/devices/hi3516ev300_lite_xm-85h50ai/general/overlay/usr/share/openipc/customizer.sh
+++ b/devices/hi3516ev300_lite_xm-85h50ai/general/overlay/usr/share/openipc/customizer.sh
@@ -25,6 +25,12 @@ fw_setenv ptz_port /dev/ttyAMA0
 fw_setenv ptz_caps 'zoom focus'
 #
 #
+# Autofocus: majestic's contrast AF engine over the ISP focus statistic,
+# driving the same zoom block. Default port/speed already match this board.
+#
+cli -s .isp.autofocus.enabled true
+#
+#
 # The MCU owns the console UART, so getty must not sit on it reading the
 # MCU's bytes. The edit lands in the overlay; an upgrade that wipes the
 # overlay also wipes /etc/custom.ok, so this script runs again and the


### PR DESCRIPTION
One line, and it makes the 85H50AI the **first OpenIPC camera with working autofocus on HiSilicon**: the customizer enables majestic's new contrast AF engine, which reads the ISP's BE AF zone statistics and drives this board's XM zoom block over the same UART the WebUI pad uses, serialised by the same port lock. The engine defaults to off everywhere — a lens without a focus motor must not grow an `/autofocus` endpoint — so the profile of the board it was proven on is exactly where the switch belongs. Port and speed defaults already match this board.

The WebUI side ([majestic-webui#265](https://github.com/OpenIPC/majestic-webui/pull/265)) grows an **AF** button in the pad's focus group and books a settle-gated pass after each zoom step.

Verified end to end on the lab unit: from total blur to a tack-sharp frame, fv 30 → 5126 against a 5606 peak in 21 s; the zoom-then-auto-AF flow re-converges in one pass. `ci-matrix.py --self-test` green.

**Ordering:** merges after the AF engine is in a release the builder image picks up; until then the flag is inert (majestic without the engine ignores unknown config keys and the WebUI probes majestic's config before showing the button).
