### PR TITLE
excludes: strip two sensors these boards cannot use, and a dead f2fs entry

### DIFF
--- a/devices/hi3518ev200_lite_qtech-qvc-ipc-136w/general/scripts/excludes/hi3518ev200_lite.list
+++ b/devices/hi3518ev200_lite_qtech-qvc-ipc-136w/general/scripts/excludes/hi3518ev200_lite.list
@@ -54,4 +54,3 @@
 #
 /lib/modules/4.9.37/kernel/drivers/net/wireless/mediatek/mt7601u/mt7601u.ko
 /lib/modules/4.9.37/kernel/drivers/staging/rtl8188eu/r8188eu.ko
-/lib/modules/4.9.37/kernel/fs/f2fs/f2fs.ko

--- a/devices/hi3518ev200_lite_smartwares-cip-37210/general/scripts/excludes/hi3518ev200_lite.list
+++ b/devices/hi3518ev200_lite_smartwares-cip-37210/general/scripts/excludes/hi3518ev200_lite.list
@@ -54,4 +54,3 @@
 #
 /lib/modules/4.9.37/kernel/drivers/net/wireless/mediatek/mt7601u/mt7601u.ko
 /lib/modules/4.9.37/kernel/drivers/staging/rtl8188eu/r8188eu.ko
-/lib/modules/4.9.37/kernel/fs/f2fs/f2fs.ko

--- a/devices/hi3518ev200_lite_switcam-hs303-v2/general/scripts/excludes/hi3518ev200_lite.list
+++ b/devices/hi3518ev200_lite_switcam-hs303-v2/general/scripts/excludes/hi3518ev200_lite.list
@@ -54,4 +54,3 @@
 #
 /lib/modules/4.9.37/kernel/drivers/net/wireless/mediatek/mt7601u/mt7601u.ko
 /lib/modules/4.9.37/kernel/drivers/staging/rtl8188eu/r8188eu.ko
-/lib/modules/4.9.37/kernel/fs/f2fs/f2fs.ko

--- a/devices/hi3518ev200_lite_switcam-hs303/general/scripts/excludes/hi3518ev200_lite.list
+++ b/devices/hi3518ev200_lite_switcam-hs303/general/scripts/excludes/hi3518ev200_lite.list
@@ -55,4 +55,3 @@
 #
 /lib/modules/4.9.37/kernel/drivers/net/wireless/mediatek/mt7601u/mt7601u.ko
 /lib/modules/4.9.37/kernel/drivers/staging/rtl8188eu/r8188eu.ko
-/lib/modules/4.9.37/kernel/fs/f2fs/f2fs.ko

--- a/devices/hi3518ev200_lite_vstarcam-c8892wip/general/scripts/excludes/hi3518ev200_lite.list
+++ b/devices/hi3518ev200_lite_vstarcam-c8892wip/general/scripts/excludes/hi3518ev200_lite.list
@@ -52,4 +52,3 @@
 /usr/lib/sensors/libsns_sc2235.so
 #
 /lib/modules/4.9.37/kernel/drivers/staging/rtl8188eu/r8188eu.ko
-/lib/modules/4.9.37/kernel/fs/f2fs/f2fs.ko

--- a/devices/ssc333_lite_babysense-see-hd-ip206/general/scripts/excludes/ssc333_lite.list
+++ b/devices/ssc333_lite_babysense-see-hd-ip206/general/scripts/excludes/ssc333_lite.list
@@ -9,6 +9,7 @@
 /etc/sensors/sc223a.bin
 /etc/sensors/sc2335.bin
 /etc/sensors/sc2336.bin
+/etc/sensors/sc3336.bin
 /etc/sensors/sc3338.bin
 /etc/sensors/sc401ai.bin
 #
@@ -20,12 +21,14 @@
 /lib/modules/4.9.84/sigmastar/sensor_jxf37_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_jxq03_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_os02g10_mipi.ko
+/lib/modules/4.9.84/sigmastar/sensor_os03b10_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc200ai_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc2239_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc223a_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc2335_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc2336_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc3335_mipi.ko
+/lib/modules/4.9.84/sigmastar/sensor_sc3336_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc3338_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc401ai_mipi.ko
 #

--- a/devices/ssc333_lite_meari-speed-6s/general/scripts/excludes/ssc333_lite.list
+++ b/devices/ssc333_lite_meari-speed-6s/general/scripts/excludes/ssc333_lite.list
@@ -10,6 +10,7 @@
 /etc/sensors/sc2335.bin
 /etc/sensors/sc2336.bin
 /etc/sensors/sc2338.bin
+/etc/sensors/sc3336.bin
 /etc/sensors/sc3338.bin
 /etc/sensors/sc401ai.bin
 #
@@ -21,6 +22,7 @@
 /lib/modules/4.9.84/sigmastar/sensor_imx335_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_jxq03_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_os02g10_mipi.ko
+/lib/modules/4.9.84/sigmastar/sensor_os03b10_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc200ai_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc2239_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc223a_mipi.ko
@@ -28,6 +30,7 @@
 /lib/modules/4.9.84/sigmastar/sensor_sc2336_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc2338_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc3335_mipi.ko
+/lib/modules/4.9.84/sigmastar/sensor_sc3336_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc3338_mipi.ko
 /lib/modules/4.9.84/sigmastar/sensor_sc401ai_mipi.ko
 #


### PR DESCRIPTION
## Summary

Two exclude-list corrections, both files the boards cannot use. This is the
builder half of the 8 MB NOR overflow; the bytes that actually fix it are in
OpenIPC/firmware#2399, and this should land alongside it.

**`ssc333_lite.list` on `meari-speed-6s` and `babysense-see-hd-ip206` never
learnt about two sensors.** `sensor_sc3336_mipi.ko`, `sensor_os03b10_mipi.ko`
and `sc3336.bin` were added to `sigmastar-osdrv-sensors` after these lists were
written, so every image of these two boards has been carrying them. Meari is
JXF37, Babysense is GC2053; neither can use either sensor, and no board in the
README's table uses SC3336 or OS03B10 at all.

Scoped to these two devices deliberately. The other nine infinity6b0 profiles
ship the same two files, but `ssc333_lite_tp-link-tapo-c110-v26` has `?` in the
sensor column of the README, and I am not going to strip a sensor blob from a
board whose sensor nobody has written down. Worth a follow-up once that is
identified.

**Five `hi3518ev200_lite.list` files carry a dead entry.** `f2fs.ko` has not
been built since F2FS was switched off upstream — `# CONFIG_F2FS_FS is not set`
in `hi3518ev200.generic.config` — and every build has been printing

```
excludes: /lib/modules/4.9.37/kernel/fs/f2fs/f2fs.ko matched no file
excludes: 1 of 55 entries in hi3518ev200_lite.list matched no file
```

for it. No bytes either way; it removes a warning that otherwise trains you to
ignore that line, which is the line that tells you an exclude has gone stale.

## Measured

Rebuilt from the shipped `nightly-20260909-e0a643f` images with the same
squashfs parameters the build uses (`-noappend -b 131072 -comp xz` under
fakeroot). The unmodified tree reproduces each published image byte-exactly —
5,238,784 for switcam-hs303 and 5,226,496 for babysense — so these are real
flash, not compression estimates.

| board | rootfs.squashfs | after |
| --- | --- | --- |
| `ssc333_lite_meari-speed-6s` | 5108 KB | 5092 KB |
| `ssc333_lite_babysense-see-hd-ip206` | 5104 KB | 5092 KB |

Against the 5128 KB these two measured on the failing run, that is not on its
own enough to clear 5120 KB with any margin worth having — hence the firmware
PR, which takes another 32 KB out of the same two images.

`ci-matrix.py --self-test` passes (114 devices, 15 smoke, 39 cases).
